### PR TITLE
Add check for negative numbers in /pull

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -4188,7 +4188,7 @@ do
 		end
 		if (lastMapID and tonumber(lastMapID) ~= LastInstanceMapID) or (not lastMapID and DBM.Options.DontShowPTNoID) then return end
 		timer = tonumber(timer or 0)
-		if timer > 60 then
+		if timer > 60 or timer < 0 then -- Avoid negative numbers
 			return
 		end
 		if not dummyMod then


### PR DESCRIPTION
I noticed that /pull accepts negative numbers, which instantly sends two messages (e.g. "Pull in -2 seconds" and "Pull now!") and creates an odd timer. `/pull -2` starts a 16 second countdown that doesn't do anything when it reaches 0, while `/pull -10` starts a similar countdown, but of 10 seconds instead.

This change simply treats negative numbers the same as `/pull`s of greater than 60 seconds.

I suppose there could be some use for instant pull alerts, but it would be better to find a solution that doesn't rely on negative `/pull` numbers (possibly just -1 in that case), as it instantly sends two alerts and creates a weird countdown.