### PR TITLE
Updated the Black Scar taunt stack amount

### DIFF
--- a/DBM-Nyalotha/CarapaceofNZoth.lua
+++ b/DBM-Nyalotha/CarapaceofNZoth.lua
@@ -312,7 +312,7 @@ function mod:SPELL_AURA_APPLIED(args)
 		end
 	elseif spellId == 315954 then
 		local amount = args.amount or 1
-		if amount >= 2 then
+		if amount >= 3 then
 			if args:IsPlayer() then
 				specWarnBlackScar:Show(amount)
 				specWarnBlackScar:Play("stackhigh")


### PR DESCRIPTION
Taunting at 2 stacks is not enough time for a tank to drop his/her stacks.