### PR TITLE
Enable Plater Nameplates for Nameplate Auras

### DIFF
--- a/DBM-Core/DBM-Nameplate.lua
+++ b/DBM-Core/DBM-Nameplate.lua
@@ -232,7 +232,7 @@ end)
 
 --Add more nameplate mods as they gain support
 function nameplateFrame:SupportedNPMod()
-    if KuiNameplates or TidyPlatesThreatDBM then return true end
+    if KuiNameplates or TidyPlatesThreatDBM or Plater then return true end
     return false
 end
 


### PR DESCRIPTION
Plater supports this feature with Plater-v8.3.0.288-Retail-2-gde419dd-alpha and later.