### PR TITLE
Gui fixes1

### DIFF
--- a/DBM-GUI/modules/MainFrame.lua
+++ b/DBM-GUI/modules/MainFrame.lua
@@ -162,7 +162,9 @@ for i = 1, math.floor(UIParent:GetHeight() / 18) do
 	button.text = button:CreateFontString(button:GetName() .. "Text", "ARTWORK", "GameFontNormalSmall")
 	button:RegisterForClicks("LeftButtonUp")
 	button:SetScript("OnClick", function(self)
-		frame:SelectButton(button)
+		frame:ClearSelection()
+		frame.tabs[frame.tab].selection = button
+		button:LockHighlight()
 		DBM_GUI.currentViewing = self.element
 		frame:DisplayFrame(self.element)
 	end)

--- a/DBM-GUI/modules/MainFrame.lua
+++ b/DBM-GUI/modules/MainFrame.lua
@@ -41,7 +41,6 @@ frame:SetScript("OnShow", function(self)
 	if self.firstshow then
 		self.firstshow = false
 		self:ShowTab(1)
-		self:UpdateMenuFrame()
 	end
 end)
 frame:SetScript("OnHide", function()
@@ -49,11 +48,14 @@ frame:SetScript("OnHide", function()
 end)
 frame:SetScript("OnDragStart", frame.StartMoving)
 frame:SetScript("OnDragStop", function(self)
-	frame:StopMovingOrSizing()
+	self:StopMovingOrSizing()
 	local point, _, _, x, y = self:GetPoint(1)
 	DBM.Options.GUIPoint = point
 	DBM.Options.GUIX = x
 	DBM.Options.GUIY = y
+end)
+frame:SetScript("OnSizeChanged", function(self)
+	self:UpdateMenuFrame()
 end)
 frame.tabs = {}
 
@@ -163,6 +165,9 @@ for i = 1, math.floor(UIParent:GetHeight() / 18) do
 	button:RegisterForClicks("LeftButtonUp")
 	button:SetScript("OnClick", function(self)
 		frame:ClearSelection()
+		for _, tab in ipairs(frame.tabs) do
+			tab.selection = nil
+		end
 		frame.tabs[frame.tab].selection = button
 		button:LockHighlight()
 		DBM_GUI.currentViewing = self.element

--- a/DBM-GUI/modules/MainFrame.lua
+++ b/DBM-GUI/modules/MainFrame.lua
@@ -66,6 +66,7 @@ frameResize:SetScript("OnMouseDown", function()
 end)
 frameResize:SetScript("OnMouseUp", function()
 	frame:StopMovingOrSizing()
+	frame:UpdateMenuFrame()
 	local container = _G[frame:GetName() .. "PanelContainer"]
 	if container.displayedFrame then
 		frame:DisplayFrame(container.displayedFrame)
@@ -152,15 +153,15 @@ frameList:SetPoint("BOTTOMLEFT", frameWebsite, "BOTTOMLEFT", 0, 14)
 frameList:SetScript("OnShow", function()
 	frame:UpdateMenuFrame()
 end)
+frameList.offset = 0
 frameList:SetBackdropBorderColor(0.6, 0.6, 0.6, 1)
 frameList.buttons = {}
-for i = 1, (frameList:GetHeight() - 8) / 18 do
+for i = 1, math.floor(UIParent:GetHeight() / 18) do
 	local button = CreateFrame("Button", frameList:GetName() .. "Button" .. i, frameList)
 	button:SetHeight(18)
 	button.text = button:CreateFontString(button:GetName() .. "Text", "ARTWORK", "GameFontNormalSmall")
 	button:RegisterForClicks("LeftButtonUp")
 	button:SetScript("OnClick", function(self)
-		frame:ClearSelection()
 		frame:SelectButton(button)
 		DBM_GUI.currentViewing = self.element
 		frame:DisplayFrame(self.element)
@@ -202,22 +203,21 @@ else
 	frameListList:SetBackdrop(frameListList.backdropInfo)
 end
 frameListList:SetBackdropBorderColor(0.6, 0.6, 0.6, 0.6)
-frameListList.offset = 0
 frameListList:SetScript("OnVerticalScroll", function(self, offset)
 	local scrollbar = _G[self:GetName() .. "ScrollBar"]
 	local _, max = scrollbar:GetMinMaxValues()
 	scrollbar:SetValue(offset)
 	_G[self:GetName() .. "ScrollBarScrollUpButton"]:SetEnabled(offset ~= 0)
 	_G[self:GetName() .. "ScrollBarScrollDownButton"]:SetEnabled(scrollbar:GetValue() - max ~= 0)
-	self.offset = math.floor((offset / 18) + 0.5)
-	frame:UpdateMenuFrame(self:GetParent())
+	frameList.offset = math.floor((offset / 18) + 0.5)
+	frame:UpdateMenuFrame()
 end)
 local frameListScrollBar = _G[frameListList:GetName() .. "ScrollBar"]
 frameListScrollBar:SetMinMaxValues(0, 11)
 frameListScrollBar:SetValueStep(18)
 frameListScrollBar:SetValue(0)
 frameList:SetScript("OnMouseWheel", function(_, delta)
-	frameListScrollBar:SetValue(frameListScrollBar:GetValue() + (delta * 18))
+	frameListScrollBar:SetValue(frameListScrollBar:GetValue() - (delta * 18))
 end)
 local scrollUpButton = _G[frameListScrollBar:GetName() .. "ScrollUpButton"]
 scrollUpButton:Disable()

--- a/DBM-GUI/modules/MainFramePrototype.lua
+++ b/DBM-GUI/modules/MainFramePrototype.lua
@@ -1,6 +1,6 @@
 CreateFrame("Frame", "DBM_GUI_OptionsFrame", UIParent, DBM:IsAlpha() and "BackdropTemplate")
 
-function DBM_GUI_OptionsFrame:UpdateMenuFrame(list)
+function DBM_GUI_OptionsFrame:UpdateMenuFrame()
 	local listFrame = list or _G["DBM_GUI_OptionsFrameList"]
 	if not listFrame.buttons then
 		return
@@ -11,30 +11,27 @@ function DBM_GUI_OptionsFrame:UpdateMenuFrame(list)
 			table.insert(displayedElements, element.frame)
 		end
 	end
-	local bigList = #displayedElements > #listFrame.buttons
-	if bigList then
+	local bigList = math.floor((listFrame:GetHeight() - 8) / 18)
+	if #displayedElements > bigList then
 		_G[listFrame:GetName() .. "List"]:Show()
+		_G[listFrame:GetName() .. "ListScrollBar"]:SetMinMaxValues(0, (#displayedElements - test) * 18)
 	else
 		_G[listFrame:GetName() .. "List"]:Hide()
-	end
-	for _, button in next, listFrame.buttons do
-		button:SetWidth(bigList and 185 or 209)
-	end
-	if #displayedElements > #listFrame.buttons then
-		_G[listFrame:GetName() .. "ListScrollBar"]:SetMinMaxValues(0, (#displayedElements - #listFrame.buttons) * 18)
-	else
 		_G[listFrame:GetName() .. "ListScrollBar"]:SetValue(0)
 	end
-	if listFrame.selection then
-		DBM_GUI_OptionsFrame:ClearSelection()
+	for _, button in ipairs(listFrame.buttons) do
+		button:SetWidth(bigList and 185 or 209)
+	end
+	if self.selection then
+		self:SelectButton(self.selection)
 	end
 	local offset = listFrame.offset or 0
 	for i = 1, #listFrame.buttons do
 		local element = displayedElements[i + offset]
-		if not element then
+		if not element or i > bigList then
 			listFrame.buttons[i]:Hide()
 		else
-			DBM_GUI_OptionsFrame:DisplayButton(listFrame.buttons[i], element)
+			self:DisplayButton(listFrame.buttons[i], element)
 		end
 	end
 end
@@ -59,17 +56,12 @@ function DBM_GUI_OptionsFrame:DisplayButton(button, element)
 	button.text:Show()
 end
 
-function DBM_GUI_OptionsFrame:ClearSelection()
-	local listFrame = _G["DBM_GUI_OptionsFrameList"]
-	for _, button in ipairs(listFrame.buttons) do
+function DBM_GUI_OptionsFrame:SelectButton(button)
+	for _, button in ipairs(_G["DBM_GUI_OptionsFrameList"].buttons) do
 		button:UnlockHighlight()
 	end
-	listFrame.selection = nil
-end
-
-function DBM_GUI_OptionsFrame:SelectButton(button)
 	button:LockHighlight()
-	_G["DBM_GUI_OptionsFrameList"].selection = button.element
+	self.selection = button
 end
 
 function DBM_GUI_OptionsFrame:DisplayFrame(frame, forceChange)

--- a/DBM-GUI/modules/MainFramePrototype.lua
+++ b/DBM-GUI/modules/MainFramePrototype.lua
@@ -107,6 +107,8 @@ function DBM_GUI_OptionsFrame:DisplayFrame(frame, forceChange)
 		end
 	else
 		scrollBar:Hide()
+		scrollBar:SetValue(0)
+		scrollBar:SetMinMaxValues(0, 0)
 		for _, child in pairs({ frame:GetChildren() }) do
 			if child.mytype == "area" then
 				child:SetPoint("TOPRIGHT", DBM_GUI_OptionsFramePanelContainerFOV, "TOPRIGHT", -5, 0)

--- a/DBM-GUI/modules/MainFramePrototype.lua
+++ b/DBM-GUI/modules/MainFramePrototype.lua
@@ -6,9 +6,13 @@ function DBM_GUI_OptionsFrame:UpdateMenuFrame()
 		return
 	end
 	local displayedElements = {}
+	self:ClearSelection()
 	if self.tab then
 		for _, element in ipairs(DBM_GUI.frameTypes[self.tab]:GetVisibleTabs()) do
 			table.insert(displayedElements, element.frame)
+		end
+		if self.tabs[self.tab].selection then
+			self.tabs[self.tab].selection:LockHighlight()
 		end
 	end
 	local bigList = math.floor((listFrame:GetHeight() - 8) / 18)
@@ -21,9 +25,6 @@ function DBM_GUI_OptionsFrame:UpdateMenuFrame()
 	end
 	for _, button in ipairs(listFrame.buttons) do
 		button:SetWidth(bigList and 185 or 209)
-	end
-	if self.selection then
-		self:SelectButton(self.selection)
 	end
 	local offset = listFrame.offset or 0
 	for i = 1, #listFrame.buttons do
@@ -56,12 +57,10 @@ function DBM_GUI_OptionsFrame:DisplayButton(button, element)
 	button.text:Show()
 end
 
-function DBM_GUI_OptionsFrame:SelectButton(button)
+function DBM_GUI_OptionsFrame:ClearSelection()
 	for _, button in ipairs(_G["DBM_GUI_OptionsFrameList"].buttons) do
 		button:UnlockHighlight()
 	end
-	button:LockHighlight()
-	self.selection = button
 end
 
 function DBM_GUI_OptionsFrame:DisplayFrame(frame, forceChange)
@@ -183,7 +182,6 @@ function DBM_GUI_OptionsFrame:CreateTab(tab)
 end
 
 function DBM_GUI_OptionsFrame:ShowTab(tab)
-	self:ClearSelection()
 	self.tab = tab
 	self:UpdateMenuFrame()
 	for i = 1, #self.tabs do

--- a/DBM-GUI/modules/MainFramePrototype.lua
+++ b/DBM-GUI/modules/MainFramePrototype.lua
@@ -1,7 +1,7 @@
 CreateFrame("Frame", "DBM_GUI_OptionsFrame", UIParent, DBM:IsAlpha() and "BackdropTemplate")
 
 function DBM_GUI_OptionsFrame:UpdateMenuFrame()
-	local listFrame = list or _G["DBM_GUI_OptionsFrameList"]
+	local listFrame = _G["DBM_GUI_OptionsFrameList"]
 	if not listFrame.buttons then
 		return
 	end
@@ -18,7 +18,7 @@ function DBM_GUI_OptionsFrame:UpdateMenuFrame()
 	local bigList = math.floor((listFrame:GetHeight() - 8) / 18)
 	if #displayedElements > bigList then
 		_G[listFrame:GetName() .. "List"]:Show()
-		_G[listFrame:GetName() .. "ListScrollBar"]:SetMinMaxValues(0, (#displayedElements - test) * 18)
+		_G[listFrame:GetName() .. "ListScrollBar"]:SetMinMaxValues(0, (#displayedElements - bigList) * 18)
 	else
 		_G[listFrame:GetName() .. "List"]:Hide()
 		_G[listFrame:GetName() .. "ListScrollBar"]:SetValue(0)


### PR DESCRIPTION
Fixed;

- Mod list doesn't update DURING resize drag, causing list to possibly go out of bounds. This is minor though, as it'll self correct when drag finished.
- New bug with SetSelected highlight fix. Highlight selection doesn't clear previous selection from different tab (ie, selecting a mod on bosses tab, then selecting a panel on options tab, both remain selected even though only one panel is active. Selection from previous tab should clear
- Mouse wheel now scrolls frames that shouldn't be scrolled, which can cause you to scroll into empty non existent space