### PR TITLE
Flash improvements for optimization

### DIFF
--- a/DBM-Core/DBM-Flash.lua
+++ b/DBM-Core/DBM-Flash.lua
@@ -8,6 +8,7 @@ DBM.Flash = {}
 --------------
 local flashFrame = DBM.Flash
 local frame, duration, elapsed, totalRepeat
+local isAlpha = DBM:IsAlpha()
 
 --------------------
 --  Create Frame  --
@@ -17,10 +18,10 @@ frame:Hide()
 frame.backdropInfo = {
 	bgFile	= "Interface\\Tooltips\\UI-Tooltip-Background" -- 137056
 }
-if not DBM:IsAlpha() then
-	frame:SetBackdrop(frame.backdropInfo)
-else
+if DBM:IsAlpha() then
 	frame:ApplyBackdrop()
+else
+	frame:SetBackdrop(frame.backdropInfo)
 end
 frame:SetAllPoints(UIParent)
 frame:SetFrameStrata("BACKGROUND")
@@ -48,7 +49,11 @@ function flashFrame:Show(red, green, blue, dur, alpha, repeatFlash)
 	duration = dur or 0.4
 	elapsed = 0
 	totalRepeat = repeatFlash or 0
-	frame.Center:SetVertexColor(red or 1, green or 0, blue or 0, alpha or 0.3)
+	if isAlpha then
+		frame.Center:SetVertexColor(red or 1, green or 0, blue or 0, alpha or 0.3)
+	else
+		frame:SetBackDropColor(red or 1, green or 0, blue or 0, alpha or 0.3)
+	end
 	frame:Show()
 end
 

--- a/DBM-Core/DBM-Flash.lua
+++ b/DBM-Core/DBM-Flash.lua
@@ -8,7 +8,6 @@ DBM.Flash = {}
 --------------
 local flashFrame = DBM.Flash
 local frame, duration, elapsed, totalRepeat
-local isAlpha = DBM:IsAlpha()
 
 --------------------
 --  Create Frame  --
@@ -49,11 +48,8 @@ function flashFrame:Show(red, green, blue, dur, alpha, repeatFlash)
 	duration = dur or 0.4
 	elapsed = 0
 	totalRepeat = repeatFlash or 0
-	if isAlpha then
-		frame.Center:SetVertexColor(red or 1, green or 0, blue or 0, alpha or 0.3)
-	else
-		frame:SetBackdropColor(red or 1, green or 0, blue or 0, alpha or 0.3)
-	end
+	-- frame.Center:SetVertexColor(red or 1, green or 0, blue or 0, alpha or 0.3) -- Uncomment in 9.0
+	frame:SetBackdropColor(red or 1, green or 0, blue or 0, alpha or 0.3)
 	frame:Show()
 end
 

--- a/DBM-Core/DBM-Flash.lua
+++ b/DBM-Core/DBM-Flash.lua
@@ -32,7 +32,7 @@ frame:Hide()
 frame:SetScript("OnUpdate", function(self, e)
 	elapsed = elapsed + e
 	if elapsed >= duration then
-		if totalRepeat == then
+		if totalRepeat == 0 then
 			self:Hide()
 			return
 		end

--- a/DBM-Core/DBM-Flash.lua
+++ b/DBM-Core/DBM-Flash.lua
@@ -7,8 +7,7 @@ DBM.Flash = {}
 --  Locals  --
 --------------
 local flashFrame = DBM.Flash
-local frame, r, g, b, t, a, duration
-local elapsed, totalRepeat = 0, 0
+local frame, duration, elapsed, totalRepeat
 
 --------------------
 --  Create Frame  --
@@ -25,35 +24,31 @@ else
 end
 frame:SetAllPoints(UIParent)
 frame:SetFrameStrata("BACKGROUND")
+frame:Hide()
 
 ------------------------
 --  OnUpdate Handler  --
 ------------------------
-do
-	frame:SetScript("OnUpdate", function(self, e)
-		elapsed = elapsed + e
-		if elapsed >= t then
+frame:SetScript("OnUpdate", function(self, e)
+	elapsed = elapsed + e
+	if elapsed >= duration then
+		if totalRepeat == then
 			self:Hide()
-			self:SetAlpha(0)
-			if totalRepeat >= 1 then
-				flashFrame:Show(r, g, b, t, a, totalRepeat - 1)
-			end
 			return
 		end
-		self:SetAlpha(-(elapsed / (duration / 2) - 1) ^ 2 + 1)
-	end)
-	frame:Hide()
-end
+		elapsed = 0
+		totalRepeat = totalRepeat - 1
+		self:SetAlpha(0)
+		return
+	end
+	self:SetAlpha(-(elapsed / (duration / 2) - 1) ^ 2 + 1)
+end)
 
 function flashFrame:Show(red, green, blue, dur, alpha, repeatFlash)
-	r, g, b, t, a = red or 1, green or 0, blue or 0, dur or 0.4, alpha or 0.3
-	duration = dur
+	duration = dur or 0.4
 	elapsed = 0
 	totalRepeat = repeatFlash or 0
-	frame:SetAlpha(0)
---	frame.backdropColor = CreateColor(r, g, b)
---	frame.backdropColorAlpha = a
-	frame:SetBackdropColor(r, g, b, a)
+	frame.Center:SetVertexColor(red or 1, green or 0, blue or 0, alpha or 0.3)
 	frame:Show()
 end
 

--- a/DBM-Core/DBM-Flash.lua
+++ b/DBM-Core/DBM-Flash.lua
@@ -52,7 +52,7 @@ function flashFrame:Show(red, green, blue, dur, alpha, repeatFlash)
 	if isAlpha then
 		frame.Center:SetVertexColor(red or 1, green or 0, blue or 0, alpha or 0.3)
 	else
-		frame:SetBackDropColor(red or 1, green or 0, blue or 0, alpha or 0.3)
+		frame:SetBackdropColor(red or 1, green or 0, blue or 0, alpha or 0.3)
 	end
 	frame:Show()
 end


### PR DESCRIPTION
Prevent OnUpdate from calling the Show function every time, to prevent resetting same values over again
Set the frame's color ONCE on creation, not on every loop (See above)
Remove usage of t, as it's same valued as duration in its usages
Replaced SetBackdropColor with SetVertexColor, as it prevents an if check inside Backdrop Mixin
Don't call Hide() on every instance, and then Show() it again.
Don't call SetAlpha(0) on usage of Hide() as it's not visible anyway