### PR TITLE
Support for CustomSounds (the hacky way of installing sounds)

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -6846,7 +6846,7 @@ do
 		LSMMediaCacheBuilt = true
 	end
 
-	function DBM:ValidateSound(path, log)
+	function DBM:ValidateSound(path, log, ignoreCustom)
 		-- Validate LibSharedMedia
 		if not LSMMediaCacheBuilt then
 			buildLSMFileCache()
@@ -6864,7 +6864,7 @@ do
 			for split in string.gmatch(path, "[^\\/]+") do -- Matches \ and / as path delimiters (incl. more than one)
 				tinsert(splitTable, split)
 			end
-			if #splitTable >= 3 and splitTable[1]:lower() == "interface" and splitTable[2]:lower() == "addons" then -- We're an addon sound
+			if #splitTable >= 3 and splitTable[1]:lower() == "interface" and splitTable[2]:lower() == "addons" and (not ignoreCustom and splitTable[3]:lower() == "dbm-customsounds") then -- We're an addon sound
 				validateCache[path] = {
 					exists = IsAddOnLoaded(splitTable[3]),
 					AddOn = splitTable[3]
@@ -6901,7 +6901,7 @@ do
 			end
 			fireEvent("DBM_PlaySound", path)
 		else
-			if validate and not self:ValidateSound(path, true) then
+			if validate and not self:ValidateSound(path, true, true) then
 				return
 			end
 			self:Debug("PlaySoundFile playing with media " .. path, 3)

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -6864,7 +6864,7 @@ do
 			for split in string.gmatch(path, "[^\\/]+") do -- Matches \ and / as path delimiters (incl. more than one)
 				tinsert(splitTable, split)
 			end
-			if #splitTable >= 3 and splitTable[1]:lower() == "interface" and splitTable[2]:lower() == "addons" and (not ignoreCustom and splitTable[3]:lower() == "dbm-customsounds") then -- We're an addon sound
+			if #splitTable >= 3 and splitTable[1]:lower() == "interface" and splitTable[2]:lower() == "addons" and (not ignoreCustom or splitTable[3]:lower() == "dbm-customsounds") then -- We're an addon sound
 				validateCache[path] = {
 					exists = IsAddOnLoaded(splitTable[3]),
 					AddOn = splitTable[3]


### PR DESCRIPTION
Importing:
- Reports on "Interface//Addons//DBM-CustomSoundPack//sound.ogg" (Addon is actually missing)
- Reports on "Interface//Addons//DBM-CustomSounds//Custom1.ogg" (Addon cannot be detected, and assume they don't have custom sounds)

Playing:
- Reports on "Interface//Addons//DBM-CustomSoundPack//sound.ogg" (Addon is actually missing)
- Doesn't report on "Interface//Addons//DBM-CustomSounds//Custom1.ogg" (Addon cannot be detected, and assume they have custom sounds)

Test results as expected.