### PR TITLE
Add a skin dropdown for bars.

### DIFF
--- a/DBM-GUI/localization.en.lua
+++ b/DBM-GUI/localization.en.lua
@@ -337,6 +337,7 @@ L.StripTimerText			= "Strip CD/Next out of timers"
 L.KeepBar					= "Keep timer active until ability cast"
 L.KeepBar2					= "(when supported by mod)"
 L.FadeBar					= "Fade timers for out of range abilities"
+L.BarSkin					= "Bar skin"
 
 -- Tab: Global Disables & Filters
 L.TabCategory_Filters	 	= "Global Disables & Filters"

--- a/DBM-GUI/modules/options/timers/Appearance.lua
+++ b/DBM-GUI/modules/options/timers/Appearance.lua
@@ -233,6 +233,22 @@ local DisableBarFade = BarSetup:CreateCheckButton(L.NoBarFade, false, nil, nil, 
 DisableBarFade:SetPoint("TOPLEFT", BarHeightSlider, "BOTTOMLEFT", 0, -50)
 DisableBarFade.myheight = 50 -- Extra padding because right buttons are offset from sliders
 
+local skins = {}
+for id, skin in pairs(DBM.Bars:GetSkins()) do
+	table.insert(skins, {
+		text	= skin.name,
+		value	= id
+	})
+end
+if #skins > 1 then
+	local BarSkin = BarSetup:CreateDropdown(L.BarSkin, skins, "DBT", "Skin", function(value)
+		DBM.Bars:SetOption("Skin", value)
+		DBM.Bars:SetSkin(value)
+	end, 210)
+	BarSkin:SetPoint("TOPLEFT", DisableBarFade, "BOTTOMLEFT", -20, -10)
+	BarSkin.myheight = 45
+end
+
 local BarSetupSmall = BarSetupPanel:CreateArea(L.AreaTitle_BarSetupSmall)
 
 local smalldummybar = DBM.Bars:CreateDummyBar(nil, nil, SMALL)


### PR DESCRIPTION
Only displays if a user has a custom skin installed, otherwise keep it hidden to prevent users being confused.