### PR TITLE
Fix nil error (Closes #465)

### DIFF
--- a/DBM-CastleNathria/StoneborneGenerals.lua
+++ b/DBM-CastleNathria/StoneborneGenerals.lua
@@ -589,8 +589,10 @@ end
 function mod:UNIT_DIED(args)
 	local cid = self:GetCIDFromGUID(args.destGUID)
 	if cid == 172858 then--stone-legion-goliath
-		timerRavenousFeastCD:Stop(castsPerGUID[args.sourceGUID], args.destGUID)
-		timerRavenousFeastCD:Stop(castsPerGUID[args.sourceGUID]+1, args.destGUID)
+		if castsPerGUID[args.sourceGUID] then
+			timerRavenousFeastCD:Stop(castsPerGUID[args.sourceGUID], args.destGUID)
+			timerRavenousFeastCD:Stop(castsPerGUID[args.sourceGUID]+1, args.destGUID)
+		end
 	elseif cid == 173280 then--stone-legion-skirmisher
 		timerWickedSlaughterCD:Stop(args.destGUID)
 	elseif cid == 168112 then--Kaal


### PR DESCRIPTION
If they never managed to get a cast off, then they're never inserted into the table, and therefor were killed very fast indeed :)