### PR TITLE
Silence issues caused by #476

### DIFF
--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -1114,8 +1114,11 @@ function barPrototype:Update(elapsed)
 		else
 			newY = self.moveOffsetY + (-barOptions[isEnlarged and "HugeBarYOffset" or "BarYOffset"] - self.moveOffsetY) * (melapsed / 0.5)
 		end
-		frame:ClearAllPoints()
-		frame:SetPoint(self.movePoint, self.moveAnchor, self.moveRelPoint, newX, newY)
+		local _, anchorPoint = self.moveAnchor:GetPoint(1)
+		if anchorPoint ~= frame then -- Prevent a possible dependency loop issue... Just ignore and leave as be.
+			frame:ClearAllPoints()
+			frame:SetPoint(self.movePoint, self.moveAnchor, self.moveRelPoint, newX, newY)
+		end
 	elseif isMoving == "move" then
 		barIsAnimating = false
 		self.moving = nil


### PR DESCRIPTION
In some weird cases where both timers "dissapear" at the exact same moment (or idk what, but something would trigger this), just don't do any SetPoint actions, to prevent any errors being thrown.

This will have the same effect as if it failed, but just prevent the message in general.