### PR TITLE
Fix additional cases of stasis trap timers starting in wrong difficulty

### DIFF
--- a/DBM-CastleNathria/ArtificerXyMox.lua
+++ b/DBM-CastleNathria/ArtificerXyMox.lua
@@ -347,11 +347,13 @@ function mod:OnSync(msg)
 		else--When this happens, it doesn't get recast for a full minute
 			timerHyperlightSparkCD:Start(60)
 		end
-		timerStasisTrapCD:Start(10.7)
 		timerDimensionalTearCD:Start(14)
 		timerRiftBlastCD:Start(20)
 		timerSeedsofExtinctionCD:Start(21.6)
 		timerGlyphofDestructionCD:Start(27.8, self.vb.destructionCount+1)--SUCCESS
+		if self:IsHard() then
+			timerStasisTrapCD:Start(10.7)
+		end
 	elseif msg == "Phase3" then
 		self.vb.phase = 3
 		self.vb.p3FirstCast = 0--1- Tear, 2 - Annihilate/Unleashed
@@ -369,10 +371,12 @@ function mod:OnSync(msg)
 		else--When this happens, it doesn't get recast for a full minute
 			timerHyperlightSparkCD:Start(60)
 		end
-		timerStasisTrapCD:Start(10.7)
 		timerDimensionalTearCD:Start(14.4)
 		timerRiftBlastCD:Start(45.9)
 		timerGlyphofDestructionCD:Start(53.5, self.vb.destructionCount+1)--SUCCESS
+		if self:IsHard() then
+			timerStasisTrapCD:Start(10.7)
+		end
 		if self:IsMythic() then
 			timerUnleashPowerCD:Start(20)--Time until phase 3 activation edge of annihilation spell
 		else


### PR DESCRIPTION
Its handled properly on combat start and spell cast, but not phase change.