### PR TITLE
Fix renew warnings in De Other Side

### DIFF
--- a/DBM-Party-Shadowlands/DeOtherSide/DeOtherSideTrash.lua
+++ b/DBM-Party-Shadowlands/DeOtherSide/DeOtherSideTrash.lua
@@ -25,8 +25,8 @@ local specWarnRage						= mod:NewSpecialWarningSpell(333787, "Healer", nil, nil,
 local specWarnUndyingRage				= mod:NewSpecialWarningDispel(333227, "RemoveEnrage", nil, nil, 1, 2)
 --Notable Hakkar Trash
 local specWarnBladestorm				= mod:NewSpecialWarningRun(332671, "Melee", nil, nil, 2, 2)
-local specWarnRenew						= mod:NewSpecialWarningInterrupt(257397, "HasInterrupt", nil, nil, 1, 2)
-local specWarnRenewDispel				= mod:NewSpecialWarningDispel(333227, "MagicDispeller", nil, nil, 1, 2)
+local specWarnRenew						= mod:NewSpecialWarningInterrupt(332666, "HasInterrupt", nil, nil, 1, 2)
+local specWarnRenewDispel				= mod:NewSpecialWarningDispel(332666, "MagicDispeller", nil, nil, 1, 2)
 local specWarnHeal						= mod:NewSpecialWarningInterrupt(332706, "HasInterrupt", nil, nil, 1, 2)
 local specWarnHealingwave				= mod:NewSpecialWarningInterrupt(332612, "HasInterrupt", nil, nil, 1, 2)
 --Notable The Manastorms Trash


### PR DESCRIPTION
Spell IDs seemed to be wrong.

[257397](https://www.wowhead.com/spell=257397/healing-balm) is some Freehold ability, and [333227](https://www.wowhead.com/spell=333227/undying-rage) is Undying Rage from line 25. The symptoms were that there was no warning for Renew and that Magic dispellers were being told to remove Undying Rage (an Enrage effect).

Corrected spell IDs to [332666](https://www.wowhead.com/spell=332666/renew).