### PR TITLE
Delete duped env vars in GH workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    env:
-      CF_API_KEY: ${{ secrets.CF_API_KEY }}
-      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
-
     steps:
       - uses: actions/checkout@v1
         with:


### PR DESCRIPTION
They are redefined in the packager step and they are not needed in other steps.