### PR TITLE
GetDungeonInfo returns a table

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -7387,8 +7387,8 @@ function DBM:FindScenarioIDs(low, peak, contains)
 	self:AddMsg("-----------------")
 	for i = start, range do
 		local instance = GetDungeonInfo(i)
-		if instance and (not contains or contains and instance:find(contains)) then
-			self:AddMsg(i..": "..instance)
+		if instance and (not contains or contains and instance.name:find(contains)) then
+			self:AddMsg(i..": "..instance.name)
 		end
 	end
 end
@@ -7533,9 +7533,9 @@ do
 			local t = GetDungeonInfo(string.sub(name, 2))
 			if type(nameModifier) == "number" then--do nothing
 			elseif type(nameModifier) == "function" then--custom name modify function
-				t = nameModifier(t or name)
+				t = nameModifier(t and t.name or name)
 			else--default name modify
-				t = string.split(",", t or name)
+				t = string.split(",", t and t.name or name)
 			end
 			obj.localization.general.name = t or name
 		else


### PR DESCRIPTION
Change argument handling to use the new table format, rather than the old standard where it was an argument string.