### PR TITLE
Cleanup pkgmeta a bit

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -3,18 +3,14 @@ package-as: DBM-Core
 externals:
   DBM-Core/Libs/CallbackHandler-1.0: https://repos.wowace.com/wow/callbackhandler/trunk/CallbackHandler-1.0
   DBM-Core/Libs/LibChatAnims: https://repos.wowace.com/wow/libchatanims/trunk/LibChatAnims
-  DBM-Core/Libs/LibDataBroker-1.1: git://github.com/tekkub/libdatabroker-1-1.git
   DBM-Core/Libs/LibDBIcon-1.0: https://repos.wowace.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
   DBM-Core/Libs/LibDurability: https://repos.wowace.com/wow/libdurability/trunk/LibDurability
   DBM-Core/Libs/LibLatency: https://repos.wowace.com/wow/liblatency/trunk/LibLatency
   DBM-Core/Libs/LibSharedMedia-3.0: https://repos.wowace.com/wow/libsharedmedia-3-0/trunk/LibSharedMedia-3.0
   DBM-Core/Libs/LibStub: https://repos.wowace.com/wow/libstub/trunk
-  DBM-Core/Libs/LibDeflate:
-    url: https://github.com/SafeteeWoW/LibDeflate
-    tag: latest
-  DBM-Core/Libs/LibSerialize:
-    url: https://github.com/rossnichols/LibSerialize
-    tag: latest
+  DBM-Core/Libs/LibDataBroker-1.1: https://github.com/tekkub/libdatabroker-1-1
+  DBM-Core/Libs/LibDeflate: https://github.com/SafeteeWoW/LibDeflate
+  DBM-Core/Libs/LibSerialize: https://github.com/rossnichols/LibSerialize
 
 ignore:
   - DBM-Core/Libs/LibDeflate/docs


### PR DESCRIPTION
We don't need to tag "latest" as its automatically assumed
Change a git:// link to https