### PR TITLE
Update luarc.json

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,6 +1,12 @@
 {
 	"$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
 	"runtime.version": "Lua 5.1",
+	"diagnostics.disable": [
+		"empty-block",
+		"invisible",
+		"deprecated",
+		"duplicate-doc-field"
+	],
 	"diagnostics.globals": [
 		"ALL",
 		"ALWAYS",
@@ -26,6 +32,8 @@
 		"NO",
 		"NONE",
 		"OKAY",
+		"PET",
+		"PLAYER",
 		"PLAYER_DIFFICULTY_TIMEWALKER",
 		"PLAYER_DIFFICULTY1",
 		"PLAYER_DIFFICULTY2",


### PR DESCRIPTION
* Fix missing global definitions
* Disable some warnings that are slow or annoying that we don't care about anyways

The missing global definitions did not cause an error in the CI script because that script also loads the old luacheck file in addition for a smoother transition.