### PR TITLE
Special warning sounds: make first parameter optional

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -10424,7 +10424,8 @@ do
 --		["reflect"] = "target",
 	}
 
-	---@param name VPSound
+	---@param name VPSound?
+	---@param customPath? string
 	function specialWarningPrototype:Play(name, customPath)
 		local always = DBM.Options.AlwaysPlayVoice
 		local voice = DBM.Options.ChosenVoicePack2


### PR DESCRIPTION
I know that announce:Play() has the same problem but that's fixed in my other PR and I don't want these to conflict.