### PR TITLE
Split .pkgmeta by release type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
 
       - name: Create Package
         uses: BigWigsMods/packager@master
+        with:
+          # Ugly hack to use a different .pkgmeta for alpha builds to work around https://github.com/BigWigsMods/packager/issues/165
+          args: $(if [[ -z $(git tag --points-at HEAD) ]]; then echo "-m .pkgmeta-alpha" ; else echo "-m .pkgmeta" ; fi)
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.pkgmeta-alpha
+++ b/.pkgmeta-alpha
@@ -26,7 +26,8 @@ ignore:
   - DBM-Core/Libs/LibStub/tests
   - DBM-Core/Libs/LibDataBroker-1.1/README.textile
   - DBM-VPVEM/README.md
-  - DBM-Test
+  - DBM-Test/Tools
+  - DBM-Test/README.md
 
 enable-nolib-creation: no
 
@@ -43,3 +44,4 @@ move-folders:
   DBM-Core/DBM-GUI: DBM-GUI
   DBM-Core/DBM-StatusBarTimers: DBM-StatusBarTimers
   DBM-Core/DBM-VPVEM/DBM-VPVEM: DBM-VPVEM
+  DBM-Core/DBM-Test: DBM-Test

--- a/DBM-Test/DBM-Test.toc
+++ b/DBM-Test/DBM-Test.toc
@@ -1,4 +1,3 @@
-#@alpha@
 ## Interface: 100206
 ## Interface-Classic: 11502
 ## Interface-Wrath: 30403
@@ -15,5 +14,3 @@ Registry.lua
 Report.lua
 Runner.lua
 TimeWarper.lua
-
-#@end-alpha@


### PR DESCRIPTION
This allows us to fully exclude DBM-Test from release builds.