### PR TITLE
add CustomNames support for user visible names

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -536,6 +536,8 @@ do
 		end
 	end
 end
+-- this is not technically a lib and instead a standalone addon but the api is available via LibStub
+local CustomNames = C_AddOns.IsAddOnLoaded("CustomNames") and LibStub and LibStub("CustomNames")
 
 --------------------------------------------------------
 --  Cache frequently used global variables in locals  --
@@ -2815,14 +2817,17 @@ do
 	---Shortens name but custom so we add * to off realmers instead of stripping it entirely like Ambiguate does
 	---<br>Technically GetUnitName without "true" can be used to shorten name to "name (*)" but "name*" is even shorter which is why we do this
 	function DBM:GetShortServerName(name)
-		if not self.Options.StripServerName then return name end--If strip is disabled, just return name
-		local shortName, serverName = string.split("-", name)
-		if serverName and serverName ~= playerRealm and serverName ~= normalizedPlayerRealm then
-			return shortName .. "*"
-		else
-			return name
-		end
-	end
+        if not self.Options.StripServerName then return name end--If strip is disabled, just return name
+        if CustomNames then
+            name = CustomNames.Get(name)
+        end
+        local shortName, serverName = string.split("-", name)
+        if serverName and serverName ~= playerRealm and serverName ~= normalizedPlayerRealm then
+            return shortName .. "*"
+        else
+            return name
+        end
+    end
 
 	---@param guid string
 	function DBM:GetFullPlayerNameByGUID(guid)

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -2819,6 +2819,7 @@ do
 	function DBM:GetShortServerName(name)
         if not self.Options.StripServerName then return name end--If strip is disabled, just return name
         if CustomNames then
+			---@diagnostic disable-next-line: undefined-field
             name = CustomNames.Get(name)
         end
         local shortName, serverName = string.split("-", name)

--- a/DBM-Core/DBM-Core_Mainline.toc
+++ b/DBM-Core/DBM-Core_Mainline.toc
@@ -12,7 +12,7 @@
 ## Title-frFR:|cffffe00a<|r|cffff7d0aDBM Core|r|cffffe00a>|r |cff69ccf0Noyau|r
 ## Notes: Deadly Boss Mods
 ## Dependencies: DBM-StatusBarTimers
-## OptionalDependencies: LibStub, CallbackHandler-1.0, LibSharedMedia-3.0, LibChatAnims, LibDBIcon-1.0, LibDeflate, LibSerialize, LibSpecialization
+## OptionalDependencies: LibStub, CallbackHandler-1.0, LibSharedMedia-3.0, LibChatAnims, LibDBIcon-1.0, LibDeflate, LibSerialize, LibSpecialization, CustomNames
 ## SavedVariables: DBM_AllSavedOptions, DBM_MinimapIcon
 ## SavedVariablesPerCharacter: DBM_UsedProfile, DBM_UseDualProfile, DBM_CharSavedRevision
 ## IconTexture: Interface\AddOns\DBM-Core\textures\dbm_airhorn


### PR DESCRIPTION
Since the discussion in [discord](https://discord.com/channels/157608978124242945/821535537911037952/1247642335743971419) and a similar PR in [WeakAuras](https://github.com/WeakAuras/WeakAuras2/pull/4480) Didn't rly result in anything thought i'd get the ball rolling by opening a PR to add [CustomNames](https://github.com/Jodsderechte/CustomNames) support. If you want any changes/some other implementation for this e.g. as a plugin similar to the [MRT implementation](https://github.com/Jods-GH/CustomNames_MRT/blob/main/CustomNames_MRT.lua) could do that aswell. If you generally don't want to support something like this would also be fine but I think this could be useful for some people. Other things i saw implemeting similar things use custom BW versions or just hard overwrite UnitName global which creates all sorts of issues.