### PR TITLE
Add icontarget yell type that just shows 5 icons

### DIFF
--- a/DBM-Core/localization.de.lua
+++ b/DBM-Core/localization.de.lua
@@ -546,6 +546,7 @@ L.AUTO_YELL_OPTION_TEXT.shortposition	= "Schreie (mit Position), wenn du von $sp
 L.AUTO_YELL_OPTION_TEXT.combo			= "Schreie (mit angepasstem Text), wenn du gleichzeitig von $spell:%s und einem weiteren Zauber betroffen bist"
 L.AUTO_YELL_OPTION_TEXT.repeatplayer	= "Schreie wiederholt (mit Spielername) wenn du von $spell:%s betroffen bist"
 L.AUTO_YELL_OPTION_TEXT.repeaticon		= "Schreie wiederholt (mit Icon) wenn du von $spell:%s betroffen bist"
+L.AUTO_YELL_OPTION_TEXT.icontarget		= "Schreie Icons wenn du das Ziel von $spell:%s bist um andere zu warnen"
 
 L.AUTO_YELL_ANNOUNCE_TEXT.shortyell	= "%s"
 L.AUTO_YELL_ANNOUNCE_TEXT.yell		= "%s auf " .. UnitName("player")

--- a/DBM-Core/localization.en.lua
+++ b/DBM-Core/localization.en.lua
@@ -576,7 +576,8 @@ L.AUTO_YELL_OPTION_TEXT = {
 	shortposition						= "Yell (with position) when you are affected by $spell:%s",
 	combo								= "Yell (with custom text) when you are affected by $spell:%s and other spells at same time",
 	repeatplayer						= "Yell repeatedly (with player name) when you are affected by $spell:%s",
-	repeaticon							= "Yell repeatedly (with icon) when you are affected by $spell:%s"
+	repeaticon							= "Yell repeatedly (with icon) when you are affected by $spell:%s",
+	icontarget							= "Yell icons when you are targeted by $spell:%s to warn others",
 }
 L.AUTO_YELL_ANNOUNCE_TEXT = {
 	shortyell							= "%s", -- OPTIONAL
@@ -589,7 +590,8 @@ L.AUTO_YELL_ANNOUNCE_TEXT = {
 	shortposition 						= "{rt%%1$d}%s %%2$d",--Icon, Spellname, number -- OPTIONAL
 	combo								= "%s and %%s",--Spell name (from option, plus spellname given in arg)
 	repeatplayer						= UnitName("player"),--Doesn't need translation, it's just player name spam -- OPTIONAL
-	repeaticon							= "{rt%%1$d}"--Doesn't need translation. It's just icon spam -- OPTIONAL
+	repeaticon							= "{rt%%1$d}",--Doesn't need translation. It's just icon spam -- OPTIONAL
+	icontarget							= "{rt%%1$d}{rt%%1$d}{rt%%1$d}",--Doesn't need translation. It's just an icon repeated 3 times-- OPTIONAL
 }
 L.AUTO_YELL_CUSTOM_POSITION				= "{rt%d}%s"--Doesn't need translating. Has no strings (Used in niche situations such as icon repeat yells) -- OPTIONAL
 L.AUTO_YELL_CUSTOM_FADE					= "%s faded"

--- a/DBM-Core/modules/objects/Yell.lua
+++ b/DBM-Core/modules/objects/Yell.lua
@@ -79,6 +79,9 @@ end
 --Standard "Yell" object that will use SAY/YELL based on what's defined in the object (Defaulting to SAY if nil)
 --I realize object being :Yell is counter intuitive to default being "SAY" but for many years the default was YELL and it's too many years of mods to change now
 function yellPrototype:Yell(...)
+	if self.yellType == "icontarget" and not ... then -- Default to skull for icontarget
+		return self:Yell(8)
+	end
 	local text = stringUtils.pformat(self.text, ...)
 	test:Trace(self.mod, "ShowYell", self, text) -- Trace before actually showing to not run into the IsInInstance() filter while testing
 	if not IsInInstance() then--as of 8.2.5+, forbidden in outdoor world
@@ -98,6 +101,9 @@ yellPrototype.Show = yellPrototype.Yell
 
 --Force override to use say message, even when object defines "YELL"
 function yellPrototype:Say(...)
+	if self.yellType == "icontarget" and not ... then -- Default to skull for icontarget
+		return self:Say(8)
+	end
 	local text = stringUtils.pformat(self.text, ...)
 	test:Trace(self.mod, "ShowYell", self, text) -- Trace before actually showing to not run into the IsInInstance() filter while testing
 	if not IsInInstance() then--as of 8.2.5+, forbidden in outdoor world
@@ -203,4 +209,9 @@ end
 ---@overload fun(self: DBMMod, spellId, yellText, optionDefault: SpecFlags|boolean?, optionName, chatType): Yell
 function bossModPrototype:NewIconRepeatYell(...)
 	return newYell(self, "repeaticon", ...)
+end
+
+---@overload fun(self: DBMMod, spellId, yellText, optionDefault: SpecFlags|boolean?, optionName, chatType): Yell
+function bossModPrototype:NewIconTargetYell(...)
+	return newYell(self, "icontarget", ...)
 end


### PR DESCRIPTION
Most spell names have no meaning to players, especially on EU servers where people have clients in random languages. But just "💀💀💀💀💀"  gets the message of "move away" from me.