### PR TITLE
Core/Timers: add missing timerTypes to options constructor

### DIFF
--- a/DBM-Core/modules/objects/Timer.lua
+++ b/DBM-Core/modules/objects/Timer.lua
@@ -943,7 +943,7 @@ local function newTimer(self, timerType, timer, spellId, timerText, optionDefaul
 	if not self.localization.options[id] or self.localization.options[id] == id then
 		if timerType == "achievement" then
 			self.localization.options[id] = L.AUTO_TIMER_OPTIONS[timerType]:format((GetAchievementLink(spellId) or ""):gsub("%[(.+)%]", "%1"))
-		elseif timerType == "cdspecial" or timerType == "nextspecial" or timerType == "stage" or timerType == "stagecount" or timerType == "stagecountcycle" or timerType == "intermission" or timerType == "intermissioncount" or timerType == "roleplay" then--Timers without spellid, generic (do not add stagecontext here, it has spellname parsing)
+		elseif timerType == "cdspecial" or timerType == "cdcombo" or timerType == "nextspecial" or timerType == "nextcombo" or timerType == "stage" or timerType == "stagecount" or timerType == "stagecountcycle" or timerType == "intermission" or timerType == "intermissioncount" or timerType == "adds" or timerType == "addscustom" or timerType == "roleplay" or timerType == "combat" then--Timers without spellid, generic (do not add stagecontext here, it has spellname parsing)
 			self.localization.options[id] = L.AUTO_TIMER_OPTIONS[timerType]--Using more than 1 stage timer or more than 1 special timer will break this, fortunately you should NEVER use more than 1 of either in a mod
 		else
 			self.localization.options[id] = L.AUTO_TIMER_OPTIONS[timerType]:format(unparsedId)


### PR DESCRIPTION
Added:
- cdcombo
- nextcombo
- adds
- addscustom
- combat

From UI standpoint, it does not change anything, just prevents a `format` call on strings that have no substitution escapes