### PR TITLE
Tests: support UNIT_HEALTH and improve target detection

### DIFF
--- a/DBM-Test/Tools/Transcriptor-Filter.lua
+++ b/DBM-Test/Tools/Transcriptor-Filter.lua
@@ -81,7 +81,7 @@ filter.ignoredCreatureIds = set{
 	221635, -- King Thoras Trollbane
 	217228, -- Blood Beast
 	54983, -- Treant
-	212489, -- Spirit Wolf
+	212489, 219986 -- Spirit Wolf
 }
 
 


### PR DESCRIPTION
Uses UNIT_SPELLCAST_* transcriptor events to update targets and unit health/power values.

This makes health-based phase pre-warnings (e.g., Onyxia) work in tests.