### PR TITLE
Show more annoying nag if important raid mods are missing

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -3787,6 +3787,7 @@ do
 			AddMsg(self, L.MOD_AVAILABLE:format("DBM-PvP"), nil, true)
 			pvpShown = true
 		end
+		self:AnnoyingPopupCheckZone(LastInstanceMapID) -- Show extra annoying popup in SoD for current raids. People seem to be struggling with installing DBM Vanilla/SoD there.
 	end
 
 	local sodPvpZones = {

--- a/DBM-Core/DBM-Core_Cata.toc
+++ b/DBM-Core/DBM-Core_Cata.toc
@@ -13,7 +13,7 @@
 ## Notes: Deadly Boss Mods
 ## Dependencies: DBM-StatusBarTimers
 ## OptionalDependencies: LibStub, CallbackHandler-1.0, LibSharedMedia-3.0, LibChatAnims, LibDBIcon-1.0, LibDeflate, LibSerialize, LibSpecialization
-## SavedVariables: DBM_AllSavedOptions, DBM_MinimapIcon
+## SavedVariables: DBM_AllSavedOptions, DBM_MinimapIcon, DBM_AnnoyingPopupDisables
 ## SavedVariablesPerCharacter: DBM_UsedProfile, DBM_UseDualProfile, DBM_CharSavedRevision
 ## IconTexture: Interface\AddOns\DBM-Core\textures\dbm_airhorn
 ## LoadOnDemand: 0
@@ -91,6 +91,7 @@ modules\MinimapButton.lua
 modules\Notes.lua
 modules\Sounds.lua
 modules\UpdateReminder.lua
+modules\AnnoyingPopup.lua
 
 modules\objects\Difficulties.lua
 modules\objects\BossMod.lua

--- a/DBM-Core/DBM-Core_Mainline.toc
+++ b/DBM-Core/DBM-Core_Mainline.toc
@@ -13,7 +13,7 @@
 ## Notes: Deadly Boss Mods
 ## Dependencies: DBM-StatusBarTimers
 ## OptionalDependencies: LibStub, CallbackHandler-1.0, LibSharedMedia-3.0, LibChatAnims, LibDBIcon-1.0, LibDeflate, LibSerialize, LibSpecialization, CustomNames
-## SavedVariables: DBM_AllSavedOptions, DBM_MinimapIcon
+## SavedVariables: DBM_AllSavedOptions, DBM_MinimapIcon, DBM_AnnoyingPopupDisables
 ## SavedVariablesPerCharacter: DBM_UsedProfile, DBM_UseDualProfile, DBM_CharSavedRevision
 ## IconTexture: Interface\AddOns\DBM-Core\textures\dbm_airhorn
 ## LoadOnDemand: 0
@@ -91,6 +91,7 @@ modules\MinimapButton.lua
 modules\Notes.lua
 modules\Sounds.lua
 modules\UpdateReminder.lua
+modules\AnnoyingPopup.lua
 
 modules\objects\Difficulties.lua
 modules\objects\BossMod.lua

--- a/DBM-Core/DBM-Core_TBC.toc
+++ b/DBM-Core/DBM-Core_TBC.toc
@@ -13,7 +13,7 @@
 ## Notes: Deadly Boss Mods
 ## Dependencies: DBM-StatusBarTimers
 ## OptionalDependencies: LibStub, CallbackHandler-1.0, LibSharedMedia-3.0, LibChatAnims, LibDBIcon-1.0, LibDeflate, LibSerialize, LibSpecialization
-## SavedVariables: DBM_AllSavedOptions, DBM_MinimapIcon
+## SavedVariables: DBM_AllSavedOptions, DBM_MinimapIcon, DBM_AnnoyingPopupDisables
 ## SavedVariablesPerCharacter: DBM_UsedProfile, DBM_UseDualProfile, DBM_CharSavedRevision
 ## IconTexture: Interface\AddOns\DBM-Core\textures\dbm_airhorn
 ## LoadOnDemand: 0
@@ -91,6 +91,7 @@ modules\MinimapButton.lua
 modules\Notes.lua
 modules\Sounds.lua
 modules\UpdateReminder.lua
+modules\AnnoyingPopup.lua
 
 modules\objects\Difficulties.lua
 modules\objects\BossMod.lua

--- a/DBM-Core/DBM-Core_Vanilla.toc
+++ b/DBM-Core/DBM-Core_Vanilla.toc
@@ -13,7 +13,7 @@
 ## Notes: Deadly Boss Mods
 ## Dependencies: DBM-StatusBarTimers
 ## OptionalDependencies: LibStub, CallbackHandler-1.0, LibSharedMedia-3.0, LibChatAnims, LibDBIcon-1.0, LibDeflate, LibSerialize, LibSpecialization
-## SavedVariables: DBM_AllSavedOptions, DBM_MinimapIcon
+## SavedVariables: DBM_AllSavedOptions, DBM_MinimapIcon, DBM_AnnoyingPopupDisables
 ## SavedVariablesPerCharacter: DBM_UsedProfile, DBM_UseDualProfile, DBM_CharSavedRevision
 ## IconTexture: Interface\AddOns\DBM-Core\textures\dbm_airhorn
 ## LoadOnDemand: 0
@@ -91,6 +91,7 @@ modules\MinimapButton.lua
 modules\Notes.lua
 modules\Sounds.lua
 modules\UpdateReminder.lua
+modules\AnnoyingPopup.lua
 
 modules\objects\Difficulties.lua
 modules\objects\BossMod.lua

--- a/DBM-Core/DBM-Core_Wrath.toc
+++ b/DBM-Core/DBM-Core_Wrath.toc
@@ -13,7 +13,7 @@
 ## Notes: Deadly Boss Mods
 ## Dependencies: DBM-StatusBarTimers
 ## OptionalDependencies: LibStub, CallbackHandler-1.0, LibSharedMedia-3.0, LibChatAnims, LibDBIcon-1.0, LibDeflate, LibSerialize, LibSpecialization
-## SavedVariables: DBM_AllSavedOptions, DBM_MinimapIcon
+## SavedVariables: DBM_AllSavedOptions, DBM_MinimapIcon, DBM_AnnoyingPopupDisables
 ## SavedVariablesPerCharacter: DBM_UsedProfile, DBM_UseDualProfile, DBM_CharSavedRevision
 ## IconTexture: Interface\AddOns\DBM-Core\textures\dbm_airhorn
 ## LoadOnDemand: 0
@@ -91,6 +91,7 @@ modules\MinimapButton.lua
 modules\Notes.lua
 modules\Sounds.lua
 modules\UpdateReminder.lua
+modules\AnnoyingPopup.lua
 
 modules\objects\Difficulties.lua
 modules\objects\BossMod.lua

--- a/DBM-Core/localization.de.lua
+++ b/DBM-Core/localization.de.lua
@@ -641,3 +641,13 @@ L.WORLD_BUFFS.zgHeartBooty	= "Der Blutgott, der Seelenschinder, wurde besiegt! W
 L.WORLD_BUFFS.zgHeartYojamba= "Beginnt mit dem Ritual, meine Diener. Wir müssen das Herz von Hakkar wieder in das Nichts verbannen!"
 L.WORLD_BUFFS.rendHead		= "Rend Blackhand, der falsche Kriegshäuptling, ist gefallen!"
 --L.WORLD_BUFFS.blackfathomBoon						= "boon of Blackfathom"
+
+-- Annoying popup, especially for classic players
+L.DBM_INSTALL_REMINDER_HEADER	= "Unvollständige DBM-Installation entdeckt!"
+L.DBM_INSTALL_REMINDER_EXPLAIN	= "Willkommen in %s. DBM Mods für Bosse hier sind im %s welches nicht installiert ist. DBM wird keine Timer und Warnungen in dieser Zone anzeigen bis das %s installiert wird!"
+L.DBM_INSTALL_REMINDER_DISABLE	= "Alle Warnungen und Timer in dieser Zone deaktivieren." -- Used when we believe it's a user error that the mod isn't installed (i.e., current raids)
+L.DBM_INSTALL_REMINDER_DISABLE2 = "Diese Nachricht für dieses Paket nicht nochmal anzeigen." -- Used for unimportant mods, i.e., dungeons
+L.DBM_INSTALL_REMINDER_DL_WAGO	= "Kopieren um von Wago.io herunterzuladen"
+L.DBM_INSTALL_REMINDER_DL_CURSE	= "Kopieren um von Curse herunterzuladen"
+L.DBM_INSTALL_PACKAGE_VANILLA	= "Vanilla und Season of Discovery Paket"
+L.DBM_INSTALL_PACKAGE_DUNGEON	= "Dungeons, Delves und Events Paket"

--- a/DBM-Core/localization.en.lua
+++ b/DBM-Core/localization.en.lua
@@ -680,3 +680,13 @@ L.WORLD_BUFFS = {
 	rendHead							= "The false Warchief, Rend Blackhand, has fallen!",
 	blackfathomBoon						= "boon of Blackfathom"
 }
+
+-- Annoying popup, especially for classic players
+L.DBM_INSTALL_REMINDER_HEADER	= "Incomplete DBM installation detected!"
+L.DBM_INSTALL_REMINDER_EXPLAIN	= "Welcome to %s. DBM mods for bosses here are in the %s which you do not have installed. DBM will not show timers or warnings in this zone unless you install the %s!"
+L.DBM_INSTALL_REMINDER_DISABLE	= "Disable all DBM warnings and timers in this zone." -- Used when we believe it's a user error that the mod isn't installed (i.e., current raids)
+L.DBM_INSTALL_REMINDER_DISABLE2 = "Do not show this message again for this package." -- Used for unimportant mods, i.e., dungeons
+L.DBM_INSTALL_REMINDER_DL_WAGO	= "Copy this to download from Wago.io"
+L.DBM_INSTALL_REMINDER_DL_CURSE	= "Copy this to download from Curse"
+L.DBM_INSTALL_PACKAGE_VANILLA	= "Vanilla and Season of Discovery package"
+L.DBM_INSTALL_PACKAGE_DUNGEON	= "Dungeons, Delves, and Events package"

--- a/DBM-Core/modules/AnnoyingPopup.lua
+++ b/DBM-Core/modules/AnnoyingPopup.lua
@@ -1,0 +1,181 @@
+local L = DBM_CORE_L
+
+---@class DBM
+local DBM = DBM
+
+---@type DBMAnnoyingPopup
+local frame
+
+local callback
+
+local function createEditBox()
+	local editBox = CreateFrame("EditBox", nil, frame)
+	local editBoxLeft = editBox:CreateTexture(nil, "BACKGROUND")
+	editBoxLeft:SetTexture(130959)--"Interface\\ChatFrame\\UI-ChatInputBorder-Left"
+	editBoxLeft:SetHeight(32)
+	editBoxLeft:SetWidth(32)
+	editBoxLeft:SetPoint("LEFT", -14, 0)
+	editBoxLeft:SetTexCoord(0, 0.125, 0, 1)
+	local editBoxRight = editBox:CreateTexture(nil, "BACKGROUND")
+	editBoxRight:SetTexture(130960)--"Interface\\ChatFrame\\UI-ChatInputBorder-Right"
+	editBoxRight:SetHeight(32)
+	editBoxRight:SetWidth(32)
+	editBoxRight:SetPoint("RIGHT", 6, 0)
+	editBoxRight:SetTexCoord(0.875, 1, 0, 1)
+	local editBoxMiddle = editBox:CreateTexture(nil, "BACKGROUND")
+	editBoxMiddle:SetTexture(130960)--"Interface\\ChatFrame\\UI-ChatInputBorder-Right"
+	editBoxMiddle:SetHeight(32)
+	editBoxMiddle:SetWidth(1)
+	editBoxMiddle:SetPoint("LEFT", editBoxLeft, "RIGHT")
+	editBoxMiddle:SetPoint("RIGHT", editBoxRight, "LEFT")
+	editBoxMiddle:SetTexCoord(0, 0.9375, 0, 1)
+	editBox:SetHeight(32)
+	editBox:SetWidth(375)
+	editBox:SetFontObject(GameFontHighlight)
+	editBox:SetTextInsets(0, 0, 0, 1)
+	editBox:SetFocus()
+	editBox:SetScript("OnTextChanged", function(self)
+		self:SetText(self.text)
+		self:HighlightText()
+	end)
+	local function highlight(self)
+		self:HighlightText()
+	end
+	editBox:SetScript("OnEnter", highlight)
+	editBox:SetScript("OnMouseUp", highlight)
+	editBox:SetScript("OnCursorChanged", highlight)
+	return editBox
+end
+
+local function createFrame()
+	if frame then return end
+	---@class DBMAnnoyingPopup: Frame, BackdropTemplate
+	frame = CreateFrame("Frame", nil, UIParent, "BackdropTemplate")
+	frame:SetFrameStrata("FULLSCREEN_DIALOG") -- In front of other frames including DBM-GUI
+	frame:SetWidth(600)
+	frame:SetHeight(1)
+	frame:SetPoint("TOP", 0, -230)
+	frame.backdropInfo = {
+		bgFile		= "Interface\\DialogFrame\\UI-DialogBox-Background-Dark",
+		edgeFile	= "Interface\\DialogFrame\\UI-DialogBox-Border",
+		tile		= true,
+		tileSize	= 32,
+		edgeSize	= 32,
+		insets		= { left = 11, right = 12, top = 12, bottom = 11 },
+	}
+	frame:ApplyBackdrop()
+	frame.header1 = frame:CreateFontString(nil, nil, "GameFontRedLarge")
+	frame.header1:SetWidth(550)
+	frame.header1:SetHeight(0)
+	frame.header1:SetPoint("TOP", 0, -16)
+	frame.header2 = frame:CreateFontString(nil, nil, "GameFontNormal")
+	frame.header2:SetWidth(550)
+	frame.header2:SetHeight(0)
+	frame.header2:SetPoint("TOP", frame.header1, "BOTTOM", 0, -2)
+	frame.editBox1 = createEditBox()
+	frame.editBox1:SetPoint("TOP", frame.header2, "BOTTOM", 0, -20)
+	frame.editBox1Header = frame:CreateFontString(nil, nil, "GameFontNormal")
+	frame.editBox1Header:SetPoint("BOTTOMLEFT", frame.editBox1, "TOPLEFT", -4, 0)
+	frame.editBox2 = createEditBox()
+	frame.editBox2:SetPoint("TOP", frame.editBox1, "BOTTOM", 0, -18)
+	frame.editBox2Header = frame:CreateFontString(nil, nil, "GameFontNormal")
+	frame.editBox2Header:SetPoint("BOTTOMLEFT", frame.editBox2, "TOPLEFT", -4, 0)
+	frame.checkboxText = frame:CreateFontString(nil, nil, "GameFontNormal")
+	frame.checkbox = CreateFrame("CheckButton", nil, frame, "OptionsBaseCheckButtonTemplate")
+	frame.checkbox:SetPoint("RIGHT", frame.checkboxText, "LEFT")
+	frame.checkboxText:SetPoint("TOP", frame.editBox2, "BOTTOM", frame.checkbox:GetWidth() / 2, -8)
+	frame.button = CreateFrame("Button", nil, frame)
+	frame.button:SetHeight(24)
+	frame.button:SetWidth(75)
+	frame.button:SetPoint("TOP", frame.checkboxText, "BOTTOM", -frame.checkbox:GetWidth() / 2, -8)
+	frame.button:SetNormalFontObject(GameFontNormal)
+	frame.button:SetHighlightFontObject(GameFontHighlight)
+	frame.button:SetNormalTexture(frame.button:CreateTexture(nil, nil, "UIPanelButtonUpTexture"))
+	frame.button:SetPushedTexture(frame.button:CreateTexture(nil, nil, "UIPanelButtonDownTexture"))
+	frame.button:SetHighlightTexture(frame.button:CreateTexture(nil, nil, "UIPanelButtonHighlightTexture"))
+	frame.button:SetText(CLOSE)
+	frame.button:SetScript("OnClick", function()
+		if callback then callback() end
+		frame:Hide()
+	end)
+end
+
+local function resize()
+	if not frame then createFrame() end
+	local buttonY = frame.button:GetBottom()
+	local frameY = frame:GetTop()
+	frame:SetHeight(frameY - buttonY + 15)
+end
+
+-- It's kinda sad that this is needed, but I see way too many people running around in SoD without classic mods installed while at the same time complaining that DBM doesn't work.
+-- No one seems to be reading messages in ChatFrame :(
+-- /run DBM:ShowAnnoyingPopup("Incomplete DBM installation detected.\nWelcome to Molten Core", "long checkbox text", "Copy this to download from Wago.io", "https://addons.wago.io/addons/7x61xpN1", "Copy this to download from Curse", "https://www.curseforge.com/wow/addons/dbm-vanilla")
+local function show(headerLarge, headerSmall, checkbox, url1Info, url1, url2Info, url2)
+	createFrame()
+	frame.header1:SetText(headerLarge)
+	frame.header2:SetText(headerSmall)
+	frame.editBox1Header:SetText(url1Info)
+	frame.editBox2Header:SetText(url2Info)
+	frame.editBox1.text = url1
+	frame.editBox2.text = url2
+	frame.checkboxText:SetText(checkbox)
+	frame:Show()
+	resize()
+end
+
+local popupData = {
+	Vanilla = {
+		package = L.DBM_INSTALL_PACKAGE_VANILLA,
+		wagoUrl = "https://addons.wago.io/addons/7x61xpN1",
+		curseUrl = "https://www.curseforge.com/wow/addons/dbm-vanilla",
+	},
+	Dungeons = {
+		package = L.DBM_INSTALL_PACKAGE_DUNGEON,
+		wagoUrl = "https://addons.wago.io/addons/xZKxZENk",
+		curseUrl = "https://www.curseforge.com/wow/addons/deadly-boss-mods-dbm-dungeons",
+		useFriendlyMessage = true
+	}
+}
+
+local annoyingPopupZonesSoD = {
+	[249]  = {addon = "DBM-Raids-Vanilla", package = "Vanilla"},  -- Onyxia
+	[409]  = {addon = "DBM-Raids-Vanilla", package = "Vanilla"},  -- Molten Core
+	[2791] = {addon = "DBM-Azeroth",       package = "Vanilla"},  -- Azuregos (instanced in SoD), we literally wiped there to spell reflect because people didn't have this installed in my guild
+	[2784] = {addon = "DBM-Party-Vanilla", package = "Dungeons"}, -- Demon Fall Canyon in SoD, it's a bit harder than usual dungeons, so let's show a warning. Remove if too many people complain.
+}
+
+
+function DBM:ShowAnnoyingPopup(packageId, zone)
+	if DBM_AnnoyingPopupDisables and DBM_AnnoyingPopupDisables[packageId] then
+		return
+	end
+	local data = popupData[packageId]
+	if not data or not zone then
+		if DBM.Options.DebugMode then error("bad arguments") end
+		return
+	end
+	show(
+		L.DBM_INSTALL_REMINDER_HEADER,
+		L.DBM_INSTALL_REMINDER_EXPLAIN:format(zone, data.package, data.package),
+		data.useFriendlyMessage and L.DBM_INSTALL_REMINDER_DISABLE2 or L.DBM_INSTALL_REMINDER_DISABLE,
+		L.DBM_INSTALL_REMINDER_DL_WAGO,
+		data.wagoUrl,
+		L.DBM_INSTALL_REMINDER_DL_CURSE,
+		data.curseUrl
+	)
+	callback = function()
+		if frame.checkbox:GetChecked() then
+			DBM_AnnoyingPopupDisables = DBM_AnnoyingPopupDisables or {}
+			DBM_AnnoyingPopupDisables[packageId] = GetServerTime()
+		end
+	end
+end
+
+function DBM:AnnoyingPopupCheckZone(mapId)
+	if self:IsSeasonal("SeasonOfDiscovery") then -- Only SoD for now
+		local zoneInfo = annoyingPopupZonesSoD[mapId]
+		if zoneInfo and not C_AddOns.DoesAddOnExist(zoneInfo.addon) then
+			self:ShowAnnoyingPopup(zoneInfo.package, (GetInstanceInfo()))
+		end
+	end
+end


### PR DESCRIPTION
Yes, there is already a chat message that even goes "bing" every time you enter a raid without the appropriate raid module installed. Yet I routinely encounter people who don't have the raid mods installed and claim that "DBM somehow doesn't work".

![Screenshot 2024-07-28 003445](https://github.com/user-attachments/assets/fa798a3c-5b97-40e5-98f8-1327fac1ff66)
