### PR TITLE
Tests: Give mods more time to detect a wipe if necessary

### DIFF
--- a/DBM-Test/Report.lua
+++ b/DBM-Test/Report.lua
@@ -244,11 +244,21 @@ function reporter:FindPreciseShowsThatAlwaysFailed(findings)
 	end
 end
 
+function reporter:FindWipeDetectionFailure(findings)
+	if self.inCombatAfterTest then
+		findings[#findings + 1] = {
+			type = "combat-didnt-end", sortKey = 4,
+			text = ("DBM still reported a mod in combat %.1f seconds after log playback"):format(self.inCombatAfterTest)
+		}
+	end
+end
+
 function reporter:ReportFindings()
 	local findings = {}
 	self:FindUntriggeredEvents(findings)
 	self:FindSpellIdMismatches(findings)
 	self:FindPreciseShowsThatAlwaysFailed(findings)
+	self:FindWipeDetectionFailure(findings)
 	local dedup = {}
 	for _, v in ipairs(findings) do
 		dedup[v.text] = v
@@ -780,4 +790,8 @@ function reporter:UnsetErrorHandler()
 		seterrorhandler(self.oldErrorHandler)
 		self.oldErrorHandler = nil
 	end
+end
+
+function reporter:FlagCombat(waitedFor)
+	self.inCombatAfterTest = waitedFor
 end

--- a/DBM-Test/TimeWarper.lua
+++ b/DBM-Test/TimeWarper.lua
@@ -121,6 +121,10 @@ function test.TimeWarper:WaitUntil(time)
 	end
 end
 
+function test.TimeWarper:WaitFor(seconds)
+	return self:WaitUntil(self.fakeTime + seconds)
+end
+
 function test.TimeWarper:DisableSound()
 	if not self.soundDisabled then
 		DBM:AddMsg("Timewarp >= 10, disabling sounds")


### PR DESCRIPTION
I somehow got an inexplicable wipe detection failure on one mod yesterday, this isn't reproducible today. While I have no clue what actually happened the logic was a bit flawed.