### PR TITLE
Remove old event register check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
         with:
           args: "--no-color -q"
 
-      - name: Run DBM Checks
-        uses: DeadlyBossMods/DBM-Actions@master
-
       - name: LuaLS globals check
         uses: DeadlyBossMods/LuaLS-config@main
         with:


### PR DESCRIPTION
The LuaLS check is more correct, see the recent false positive here https://github.com/DeadlyBossMods/DeadlyBossMods/actions/runs/10870524775/job/30163239323