### PR TITLE
Core: Add new type of event registration

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -1094,8 +1094,13 @@ do
 			local zones = v.zones
 			local handler = v[event]
 			local modEvents = v.registeredUnitEvents
-			if handler and (not isUnitEvent or not modEvents or modEvents[event .. ...]) and (not zones or zones[LastInstanceMapID]) and not (not v.isTrashModBossFightAllowed and v.isTrashMod and #inCombat > 0) then
-				handler(v, ...)
+			if (not isUnitEvent or not modEvents or modEvents[event .. ...]) and (not zones or zones[LastInstanceMapID]) and not (not v.isTrashModBossFightAllowed and v.isTrashMod and #inCombat > 0) then
+				if handler then
+					handler(v, ...)
+				end
+				if v.OnEvent then
+					v:OnEvent(event, ...)
+				end
 			end
 		end
 	end

--- a/DBM-Core/DBM-Core_Cata.toc
+++ b/DBM-Core/DBM-Core_Cata.toc
@@ -96,6 +96,7 @@ modules\AnnoyingPopup.lua
 
 modules\objects\Difficulties.lua
 modules\objects\BossMod.lua
+modules\objects\BossModEventDispatcher.lua
 modules\objects\Localization.lua
 modules\objects\VoicePacks.lua
 modules\objects\Timer.lua

--- a/DBM-Core/DBM-Core_Mainline.toc
+++ b/DBM-Core/DBM-Core_Mainline.toc
@@ -97,6 +97,7 @@ modules\ZoneCombatScanner.lua
 
 modules\objects\Difficulties.lua
 modules\objects\BossMod.lua
+modules\objects\BossModEventDispatcher.lua
 modules\objects\Localization.lua
 modules\objects\VoicePacks.lua
 modules\objects\Timer.lua

--- a/DBM-Core/DBM-Core_TBC.toc
+++ b/DBM-Core/DBM-Core_TBC.toc
@@ -96,6 +96,7 @@ modules\AnnoyingPopup.lua
 
 modules\objects\Difficulties.lua
 modules\objects\BossMod.lua
+modules\objects\BossModEventDispatcher.lua
 modules\objects\Localization.lua
 modules\objects\VoicePacks.lua
 modules\objects\Timer.lua

--- a/DBM-Core/DBM-Core_Vanilla.toc
+++ b/DBM-Core/DBM-Core_Vanilla.toc
@@ -96,6 +96,7 @@ modules\AnnoyingPopup.lua
 
 modules\objects\Difficulties.lua
 modules\objects\BossMod.lua
+modules\objects\BossModEventDispatcher.lua
 modules\objects\Localization.lua
 modules\objects\VoicePacks.lua
 modules\objects\Timer.lua

--- a/DBM-Core/DBM-Core_Wrath.toc
+++ b/DBM-Core/DBM-Core_Wrath.toc
@@ -96,6 +96,7 @@ modules\AnnoyingPopup.lua
 
 modules\objects\Difficulties.lua
 modules\objects\BossMod.lua
+modules\objects\BossModEventDispatcher.lua
 modules\objects\Localization.lua
 modules\objects\VoicePacks.lua
 modules\objects\Timer.lua

--- a/DBM-Core/modules/objects/BossMod.lua
+++ b/DBM-Core/modules/objects/BossMod.lua
@@ -307,11 +307,23 @@ end
 ---@param ... DBMEvent|string
 function bossModPrototype:RegisterEventsInCombat(...)
 	test:Trace(self, "RegisterEvents", "InCombat", ...)
-	if self.inCombatOnlyEvents then
+	if self.inCombatOnlyEvents and select("#", ...) > 1 then
 		geterrorhandler()("combat events already set")
 	end
-	self.inCombatOnlyEvents = {...}
-	for k, v in pairs(self.inCombatOnlyEvents) do
+	if self.inCombatOnlyEvents then
+		-- Special case: allow registrating additional events if you do it one-by-one (check in the abort above)
+		-- FIXME: allow this in general if we end up keeping the new event handlers
+		local event = ...
+		for _, v in ipairs(self.inCombatOnlyEvents) do
+			if v == event then
+				return
+			end
+		end
+		self.inCombatOnlyEvents[#self.inCombatOnlyEvents + 1] = event
+	else
+		self.inCombatOnlyEvents = {...}
+	end
+	for k, v in ipairs(self.inCombatOnlyEvents) do
 		if v:sub(0, 5) == "UNIT_" and v:sub(-11) ~= "_UNFILTERED" and not v:find(" ") and v ~= "UNIT_DIED" and v ~= "UNIT_DESTROYED" then
 			-- legacy event, oh noes
 			self.inCombatOnlyEvents[k] = v .. " boss1 boss2 boss3 boss4 boss5 target focus"

--- a/DBM-Core/modules/objects/BossModEventDispatcher.lua
+++ b/DBM-Core/modules/objects/BossModEventDispatcher.lua
@@ -7,11 +7,18 @@ local DBM = private:GetPrototype("DBM")
 ---@class DBMMod
 local bossModPrototype = private:GetPrototype("DBMMod")
 
+local type = type
+
 local function handleEvent(self, event, ...)
 	local handlers = self.directEvents[event]
 	if handlers then
+		-- TODO: support UNIT_ events with some kind of reasonable filtering (by creature IDs?)
+		local arg1, _, _, _, _, _, _, _, _, _, arg11 = ...
+		local spellId = type(arg1) == "table" and arg1.spellId or arg11
 		for _, handler in ipairs(handlers) do
-			handler(self, ...)
+			if handler.unfiltered or handler[spellId] then
+				handler.func(self, ...)
+			end
 		end
 	end
 end
@@ -19,9 +26,8 @@ end
 ---@alias DBMModEventHandler fun(mod: DBMMod, args: DBMCombatLogArgs)
 
 -- Register a single event to a directly attached handler as an in-combat event.
----@overload fun(self: DBMMod, event: DBMEvent, handler: string|DBMModEventHandler)
 ---@param event DBMEvent
----@param eventArg string|number
+---@param eventArg string|number?
 ---@param handler string|DBMModEventHandler
 function bossModPrototype:RegisterEvent(event, eventArg, handler)
 	if type(eventArg) == "function" then
@@ -39,7 +45,33 @@ function bossModPrototype:RegisterEvent(event, eventArg, handler)
 	self.directEvents = self.directEvents or {}
 	local handlers = self.directEvents[event] or {}
 	self.directEvents[event] = handlers
-	handlers[#handlers + 1] = handler
+	local eventArgHandler = {func = handler}
+	if eventArg then
+		local arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 = string.split(" ", tostring(eventArg), 8)
+		if arg8 and arg8:find(" ") then
+			for _, v in ipairs{string.split(" ", tostring(eventArg))} do
+				eventArgHandler[tonumber(v) or v] = true
+			end
+		else
+			if arg1 then eventArgHandler[tonumber(arg1) or arg1] = true end
+			if arg2 then eventArgHandler[tonumber(arg2) or arg2] = true end
+			if arg3 then eventArgHandler[tonumber(arg3) or arg3] = true end
+			if arg4 then eventArgHandler[tonumber(arg4) or arg4] = true end
+			if arg5 then eventArgHandler[tonumber(arg5) or arg5] = true end
+			if arg6 then eventArgHandler[tonumber(arg6) or arg6] = true end
+			if arg7 then eventArgHandler[tonumber(arg7) or arg7] = true end
+			if arg8 then eventArgHandler[tonumber(arg8) or arg8] = true end
+		end
+	else
+		eventArgHandler.unfiltered = true
+	end
+	handlers[#handlers + 1] = eventArgHandler
 	self.OnEvent = handleEvent
-	self:RegisterEventsInCombat(event)
+	self:RegisterEventsInCombat(event .. (eventArg and (" " .. eventArg) or ""))
 end
+
+-- Register a single raw event to a directly attached handler as an in-combat event.
+---@type fun(self: DBMMod, event: DBMEvent, eventArg: string|number?, handler: fun(mod: DBMMod, ...))
+bossModPrototype.RegisterRawEvent = bossModPrototype.RegisterEvent
+
+-- These two only differ in the type signature, if these end up being used more we should support this a bit better via a LuaLS plugin

--- a/DBM-Core/modules/objects/BossModEventDispatcher.lua
+++ b/DBM-Core/modules/objects/BossModEventDispatcher.lua
@@ -1,0 +1,45 @@
+---@class DBMCoreNamespace
+local private = select(2, ...)
+
+---@class DBM
+local DBM = private:GetPrototype("DBM")
+
+---@class DBMMod
+local bossModPrototype = private:GetPrototype("DBMMod")
+
+local function handleEvent(self, event, ...)
+	local handlers = self.directEvents[event]
+	if handlers then
+		for _, handler in ipairs(handlers) do
+			handler(self, ...)
+		end
+	end
+end
+
+---@alias DBMModEventHandler fun(mod: DBMMod, args: DBMCombatLogArgs)
+
+-- Register a single event to a directly attached handler as an in-combat event.
+---@overload fun(self: DBMMod, event: DBMEvent, handler: string|DBMModEventHandler)
+---@param event DBMEvent
+---@param eventArg string|number
+---@param handler string|DBMModEventHandler
+function bossModPrototype:RegisterEvent(event, eventArg, handler)
+	if type(eventArg) == "function" then
+		return self:RegisterEvent(event, nil, eventArg)
+	end
+	if type(handler) == "string" then
+		handler = self[handler]
+		if not handler then
+			error("FIXME: lazy loading of string-typed event handlers is NYI", 2)
+		end
+	end
+	if event:find(" ") then -- TODO: decide if we should support this for consistency, but feels hacky for a single-event string
+		error("FIXME: event args must go into second parameter", 2)
+	end
+	self.directEvents = self.directEvents or {}
+	local handlers = self.directEvents[event] or {}
+	self.directEvents[event] = handlers
+	handlers[#handlers + 1] = handler
+	self.OnEvent = handleEvent
+	self:RegisterEventsInCombat(event)
+end


### PR DESCRIPTION
Registers a single event (with spell ID filters) in combat and connects it directly to a function or method.

This is experimental and not meant to be used directly in mods, but I have some ideas.