### PR TITLE
Add uncompressed log stripping for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
+      - name: Strip uncompressed test data
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          cd "${{ github.workspace }}"
+          find DBM-Test-* -name \*.lua -not -path '*/Reports/*' -print0 | xargs -0 -n1 sed -i -z 's/--@strip-from-release@.*@end-strip-from-release@/-- Raw test log stripped from release build./'
       - name: Create Package
         uses: BigWigsMods/packager@master
         env:


### PR DESCRIPTION
Works well in DBM-Vanilla; TODO is to add compressed versions and the necessary tags to all old test data