### PR TITLE
Tests: Make commit message for multi-commit pushes to test results more readable

### DIFF
--- a/.github/workflows/dbm-offline-on-push.yml
+++ b/.github/workflows/dbm-offline-on-push.yml
@@ -19,6 +19,6 @@ jobs:
           test-dbm-core-mods: true
           test-dbm-vanilla-mods: true
           test-dbm-dungeon-mods: true
-          upload-repo-commit-message: ${{ format('Core{0} {1}', ':', join(github.event.commits.*.message, '\n')) }}
+          upload-repo-commit-message: ${{ format('Core{0} {1}', ':', join(github.event.commits.*.message, ';')) }}
           upload-repo-branch: main
           upload-token: ${{ secrets.TEST_RESULT_UPLOAD_TOKEN }}


### PR DESCRIPTION
The \n doesn't actually work: https://github.com/DeadlyBossMods/DBM-Test-Results/commit/4252724e380c858be250232395bffdc67f323da3