### PR TITLE
Variance: remove obsolete code

### DIFF
--- a/DBM-Core/modules/objects/Timer.lua
+++ b/DBM-Core/modules/objects/Timer.lua
@@ -421,7 +421,6 @@ function timerPrototype:Start(timer, ...)
 		end
 		msg = msg:gsub(">.-<", stringUtils.stripServerName)
 		bar:SetText(msg, self.inlineIcon)
-		bar.hasVariance = hasVariance
 		-- FIXME: i would prefer to trace this directly in DBT, but since I want to rewrite DBT... meh.
 		test:Trace(self.mod, "StartTimer", self, timer, msg)
 		--ID (string) Internal DBM timer ID


### PR DESCRIPTION
This has no place being in Start method. Bar attributes on creation are to be managed in DBT:CreateBar

https://github.com/DeadlyBossMods/DeadlyBossMods/pull/1525#issuecomment-2643836120