### PR TITLE
Variance: fix var to non-var timers not showing while on Debug and timer<0

### DIFF
--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -346,11 +346,11 @@ do
 			newBar.lastUpdate = GetTime()
 			newBar.huge = huge or nil
 			newBar.paused = nil
-			newBar.keep = keep
 			newBar.minTimer = varianceMinTimer or nil
 			newBar.varianceDuration = varianceDuration or 0
 			newBar.hasVariance = varianceMinTimer and true or false
 			newBar:SetTimer(timer) -- This can kill the timer and the timer methods don't like dead timers
+			newBar.keep = keep -- keep this after SetTimer, not before, otherwise the bar will turn dead if Debug mode enabled and switching from var to non-var, since Update(0) will Cancel the timer
 			if newBar.dead then
 				return
 			end


### PR DESCRIPTION
Follow-up to: https://github.com/DeadlyBossMods/DeadlyBossMods/pull/1527/commits/31fb1c30e2dc7bcceb3ac4aa13815479bdc27fae

Related to: https://github.com/DeadlyBossMods/DeadlyBossMods/pull/1527

Essentially, when on DebugMode, Core overrides timer metadata "keep":
https://github.com/DeadlyBossMods/DeadlyBossMods/blob/8fd76f31f51ea865be02c7d59ad096ba380c780f/DBM-Core/modules/objects/Timer.lua#L225-L227

Which I tried to cater by checking that property on DBT:CreateBar, however, its construct does not foresee this and was Canceling the timer.