### PR TITLE
Tests: Simplify mod guessing

### DIFF
--- a/DBM-Test/Registry.lua
+++ b/DBM-Test/Registry.lua
@@ -42,46 +42,6 @@ function test:DecompressLog(testData)
 	testData.log = deserialized
 end
 
-local function loadTestAsync(testData)
-	if not testData.mod then
-		test:DecompressLog(testData)
-	end
-	if C_AddOns.IsAddOnLoaded(testData.addon) then
-		test:GuessMod(testData)
-	end
-	if testData.mod then
-		testData.mod = tostring(testData.mod) -- Canonicalize mod ids to strings because DBM:NewMod() does so internally and the UI only has the stringified ID available
-		testsByMod[testData.mod] = testsByMod[testData.mod] or {}
-		table.insert(testsByMod[testData.mod], testData)
-	end
-end
-
-test._loadTestAsyncInternal = loadTestAsync -- required for DBM-Offline which doesn't do OnUpdate outside the timewarper
-
-local testsLoading = {}
-local testLoaderFrame = CreateFrame("Frame")
-local testLoader = coroutine.create(function()
-	while true do
-		if #testsLoading > 0 then
-			local testData = testsLoading[#testsLoading]
-			testsLoading[#testsLoading] = nil
-			loadTestAsync(testData)
-		else
-			testLoaderFrame:Hide()
-			yield()
-		end
-	end
-end)
-
-testLoaderFrame:SetScript("OnUpdate", function(self)
-	if coroutine.status(testLoader) == "dead" then
-		self:Hide()
-		return
-	end
-	local ok, err = coroutine.resume(testLoader)
-	if not ok then error(err) end
-end)
-
 local addonLoadedFrame = CreateFrame("Frame")
 addonLoadedFrame:RegisterEvent("ADDON_LOADED")
 addonLoadedFrame:SetScript("OnEvent", function(self, _, addonName)
@@ -103,10 +63,16 @@ function test:DefineTest(def)
 	if self.Registry.tests[def.name] then
 		error("duplicate test name " .. def.name, 2)
 	end
+	if C_AddOns.IsAddOnLoaded(def.addon) then
+		test:GuessMod(def)
+	end
+	if def.mod then
+		def.mod = tostring(def.mod)
+		testsByMod[def.mod] = testsByMod[def.mod] or {}
+		table.insert(testsByMod[def.mod], def)
+	end
 	self.Registry.tests[def.name] = def
 	table.insert(self.Registry.sortedTests, def.name)
-	testsLoading[#testsLoading + 1] = def
-	testLoaderFrame:Show()
 end
 
 -- Deprecated, test reports were deleted in favor of DBM-Offline

--- a/DBM-Test/Tools/Shared/ParseTranscriptor.lua
+++ b/DBM-Test/Tools/Shared/ParseTranscriptor.lua
@@ -720,13 +720,15 @@ DBM.Test:DefineTest{
 	name = %s,
 	gameVersion = %s,
 	addon = %s,
-	mod = %s,
+	%s = %s,
 	instanceInfo = %s,]]
 
 function testGenerator:GetHeaderString()
 	local def = self:GetTestDefinition()
 	return headerTemplate:format(
-		literal(def.name), literal(def.gameVersion), literal(def.addon), literal(def.mod),
+		literal(def.name), literal(def.gameVersion), literal(def.addon),
+		def.encounterId and "encounterId" or "mod",
+		def.encounterId and literal(def.encounterId) or literal(def.mod),
 		instanceInfoLiteral(def.instanceInfo)
 	)
 end
@@ -770,6 +772,7 @@ function testGenerator:GetTestDefinition()
 		gameVersion = self.metadata.gameVersion,
 		addon = self:guessAddon(),
 		mod = self:guessMod(),
+		encounterId = self.metadata.encounterInfo.id,
 		instanceInfo = self.metadata.instanceInfo,
 		perspective = self.metadata.player,
 		players = resultPlayers,


### PR DESCRIPTION
Basically the test generator will put the encounterId into the metadata which removes the mess with compressed logs