### PR TITLE
Add ThreatPlates to the list of compatible addons for DBM Icon CDs

### DIFF
--- a/DBM-Core/DBM-Nameplate.lua
+++ b/DBM-Core/DBM-Nameplate.lua
@@ -503,7 +503,7 @@ local function SupportedNPModIcons()
 end
 local function SupportedNPModBars()
 	if not DBM.Options.UseNameplateHandoff then return false end
-	if _G["Plater"] then return true end--Plater support disabled for time being due to bugs in plater that prevent using glow types correctly
+	if _G["Plater"]  or _G["TidyPlatesThreatDBM"] then return true end--Plater support disabled for time being due to bugs in plater that prevent using glow types correctly
 	return false
 end
 


### PR DESCRIPTION
With version 12.2.0, ThreatPlates now supports Icon CDs from DBM as part of the BossMods widget.

Similar to SupportedNPModIcons, adding the check for TidyPlatesThreatDBM to SupportedNPModBars will prevent Icon CDs from being shown two times (from DBM and TP, unless it's disabledin TP). 