### PR TITLE
Spell rename Fixes:

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -837,7 +837,7 @@ do
 	bossModPrototype.GetRenameDefault = DBM.GetRenameDefault
 
 	function DBM:RefreshSpellRenames()
-		refreshSpellRenameCache(false)
+		refreshSpellRenameCache(true)
 	end
 	bossModPrototype.RefreshSpellRenames = DBM.RefreshSpellRenames
 

--- a/DBM-Core/modules/objects/Announce.lua
+++ b/DBM-Core/modules/objects/Announce.lua
@@ -380,7 +380,7 @@ local function setText(announceType, spellId, castTime, preWarnTime, customName)
 	else
 		baseSpellName = DBM:ParseSpellName(spellId, announceType) or CL.UNKNOWN
 	end
-	if spellId then
+	if spellId and DBM.Options.WarningShortText then
 		spellName = DBM:GetRename(spellId, baseSpellName)
 	else
 		spellName = baseSpellName
@@ -435,7 +435,8 @@ function announcePrototype:UpdateKey(altSpellId)
 		self.customName = nil
 		self.renameRevision = DBM:GetSpellRenameRevision()
 	else--Just regenerating spellName not message text because it's likely a custom text object such as NewSpecialWarning
-		self.spellName = DBM:ParseSpellName(altSpellId)
+		self.originalSpellName = DBM:ParseSpellName(altSpellId)
+		self.spellName = DBM.Options.WarningShortText and DBM:GetRename(altSpellId, self.originalSpellName) or self.originalSpellName
 	end
 end
 
@@ -489,7 +490,8 @@ function announcePrototype:Show(...) -- todo: reduce amount of unneeded strings
 				self.text = text
 				self.spellName = spellName
 			else
-				self.spellName = DBM:GetRename(self.spellId, self.spellName or DBM:ParseSpellName(self.spellId) or CL.UNKNOWN)
+				local originalSpellName = self.originalSpellName or DBM:ParseSpellName(self.spellId) or CL.UNKNOWN
+				self.spellName = DBM.Options.WarningShortText and DBM:GetRename(self.spellId, originalSpellName) or originalSpellName
 			end
 			self.renameRevision = DBM:GetSpellRenameRevision()
 		end
@@ -804,10 +806,12 @@ function bossModPrototype:NewAnnounce(text, color, icon, optionDefault, optionNa
 	end
 	icon = DBM:ParseSpellIcon(icon)
 	local spellName
+	local originalSpellName
 	local renameRevision
 	if spellID then
 		local baseSpellName = waCustomName or DBM:ParseSpellName(spellID) or CL.UNKNOWN
-		spellName = DBM:GetRename(spellID, baseSpellName)
+		originalSpellName = baseSpellName
+		spellName = DBM.Options.WarningShortText and DBM:GetRename(spellID, baseSpellName) or baseSpellName
 		renameRevision = DBM:GetSpellRenameRevision()
 	end
 	---@class Announce
@@ -823,6 +827,7 @@ function bossModPrototype:NewAnnounce(text, color, icon, optionDefault, optionNa
 			icon = icon,
 			spellId = spellID,--For WeakAuras / other callbacks
 			spellName = spellName,
+			originalSpellName = originalSpellName,
 			renameRevision = renameRevision,
 		},
 		mt

--- a/DBM-Core/modules/objects/SpecialWarning.lua
+++ b/DBM-Core/modules/objects/SpecialWarning.lua
@@ -433,7 +433,7 @@ local function setText(announceType, spellId, stacks, customName)
 	else
 		fallbackSpellName = customName or originalSpellName
 	end
-	if effectiveSpellId then
+	if effectiveSpellId and DBM.Options.SpecialWarningShortText then
 		spellName = DBM:GetRename(effectiveSpellId, fallbackSpellName, originalSpellName)
 	else
 		spellName = fallbackSpellName
@@ -481,7 +481,8 @@ function specialWarningPrototype:UpdateKey(altSpellId)
 		self.customName = nil
 		self.renameRevision = DBM:GetSpellRenameRevision()
 	else--Just regenerating spellName not message text because it's likely a custom text object such as NewSpecialWarning
-		self.spellName = DBM:ParseSpellName(altSpellId)
+		self.originalSpellName = DBM:ParseSpellName(altSpellId)
+		self.spellName = DBM.Options.SpecialWarningShortText and DBM:GetRename(altSpellId, self.originalSpellName) or self.originalSpellName
 	end
 end
 
@@ -554,7 +555,8 @@ function specialWarningPrototype:Show(...)
 				self.text = text
 				self.spellName = spellName
 			else
-				self.spellName = DBM:GetRename(self.spellId, self.spellName or DBM:ParseSpellName(self.spellId) or CL.UNKNOWN)
+				local originalSpellName = self.originalSpellName or DBM:ParseSpellName(self.spellId) or CL.UNKNOWN
+				self.spellName = DBM.Options.SpecialWarningShortText and DBM:GetRename(self.spellId, originalSpellName) or originalSpellName
 			end
 			self.renameRevision = DBM:GetSpellRenameRevision()
 		end
@@ -946,10 +948,12 @@ function bossModPrototype:NewSpecialWarning(text, optionDefault, optionName, opt
 	icon = DBM:ParseSpellIcon(icon)
 	local warningText = self.localization.warnings[text]
 	local spellName
+	local originalSpellName
 	local renameRevision
 	if spellID then
 		local baseSpellName = waCustomName or DBM:ParseSpellName(spellID) or CL.UNKNOWN
-		spellName = DBM:GetRename(spellID, baseSpellName)
+		originalSpellName = baseSpellName
+		spellName = DBM.Options.SpecialWarningShortText and DBM:GetRename(spellID, baseSpellName) or baseSpellName
 		renameRevision = DBM:GetSpellRenameRevision()
 	end
 	---@class SpecialWarning
@@ -966,6 +970,7 @@ function bossModPrototype:NewSpecialWarning(text, optionDefault, optionName, opt
 			difficulty = difficulty,
 			spellId = spellID,--For WeakAuras / other callbacks
 			spellName = spellName,
+			originalSpellName = originalSpellName,
 			renameRevision = renameRevision,
 			icon = icon,
 			voiceFile = voiceFile,

--- a/DBM-Core/modules/objects/Timer.lua
+++ b/DBM-Core/modules/objects/Timer.lua
@@ -1601,8 +1601,10 @@ function bossModPrototype:GetLocalizedTimerText(timerType, spellId, Name)
 	if spellId then
 		originalSpellName = DBM:ParseSpellName(spellId, timerType) or spellName
 	end
-	if spellId then
+	if spellId and DBM.Options.ShortTimerText then
 		spellName = DBM:GetRename(spellId, spellName, originalSpellName)
+	elseif originalSpellName then
+		spellName = originalSpellName
 	end
 	return pformat(L.AUTO_TIMER_TEXTS[timerType], spellName)
 end

--- a/DBM-GUI/modules/options/alerts/Announcements.lua
+++ b/DBM-GUI/modules/options/alerts/Announcements.lua
@@ -14,6 +14,9 @@ if not DBM:IsPostMidnight() then
 	check5 = raidwarnoptions:CreateCheckButton(L.WarningAlphabetical, true, nil, "WarningAlphabetical")
 end
 check6 = raidwarnoptions:CreateCheckButton(L.ShortTextSpellname, true, nil, "WarningShortText")
+check6:HookScript("OnClick", function()
+	DBM:RefreshSpellRenames()
+end)
 
 -- RaidWarn Font
 local Fonts = DBM_GUI:MixinSharedMedia3("font", {
@@ -134,9 +137,9 @@ resetbutton:SetScript("OnClick", function()
 	check2:SetChecked(DBM.Options.WarningIconLeft)
 	check3:SetChecked(DBM.Options.WarningIconRight)
 	check4:SetChecked(DBM.Options.WarningIconChat)
+	check6:SetChecked(DBM.Options.WarningShortText)
 	if not DBM:IsPostMidnight() then
 		check5:SetChecked(DBM.Options.WarningAlphabetical)
-		check6:SetChecked(DBM.Options.WarningShortText)
 	end
 	FontDropDown:SetSelectedValue(DBM.Options.WarningFont)
 	FontStyleDropDown:SetSelectedValue(DBM.Options.WarningFontStyle)
@@ -145,6 +148,7 @@ resetbutton:SetScript("OnClick", function()
 	FontShadow:SetChecked(DBM.Options.WarningFontShadow)
 	RaidWarnSoundDropDown:SetSelectedValue(DBM.Options.RaidWarningSound)
 	DBM:UpdateWarningOptions()
+	DBM:RefreshSpellRenames()
 end)
 
 --Raid Warning Colors

--- a/DBM-GUI/modules/options/alerts/SpecialAnnouncements.lua
+++ b/DBM-GUI/modules/options/alerts/SpecialAnnouncements.lua
@@ -18,6 +18,9 @@ if not DBM:IsPostMidnight() then
 	check5 = specArea:CreateCheckButton(L.SWarnNameInNote, true, nil, "SWarnNameInNote")
 end
 check6 = specArea:CreateCheckButton(L.ShortTextSpellname, true, nil, "SpecialWarningShortText")
+check6:HookScript("OnClick", function()
+	DBM:RefreshSpellRenames()
+end)
 
 
 local movemebutton = specArea:CreateButton(L.MoveMe, 120, 16)
@@ -476,6 +479,7 @@ resetbutton:SetScript("OnClick", function()
 	-- Set UI visuals
 	check1:SetChecked(DBM.Options.ShowSWarningsInChat)
 	check2:SetChecked(DBM.Options.SpecialWarningIcon)
+	check6:SetChecked(DBM.Options.SpecialWarningShortText)
 	FontDropDown:SetSelectedValue(DBM.Options.SpecialWarningFont)
 	FontStyleDropDown:SetSelectedValue(DBM.Options.SpecialWarningFontStyle)
 	FontShadow:SetChecked(DBM.Options.SpecialWarningFontShadow)
@@ -513,7 +517,6 @@ resetbutton:SetScript("OnClick", function()
 		check3:SetChecked(DBM.Options.SWarnClassColor)
 		check4:SetChecked(DBM.Options.SWarningAlphabetical)
 		check5:SetChecked(DBM.Options.SWarnNameInNote)
-		check6:SetChecked(DBM.Options.SpecialWarningShortText)
 		color5:SetColorRGB(DBM.Options.SpecialWarningFlashCol5[1], DBM.Options.SpecialWarningFlashCol5[2], DBM.Options.SpecialWarningFlashCol5[3])
 		flashCheck5:SetChecked(DBM.Options.SpecialWarningFlash5)
 		vibrateCheck5:SetChecked(DBM.Options.SpecialWarningVibrate5)
@@ -522,4 +525,5 @@ resetbutton:SetScript("OnClick", function()
 		flashRepSlider5:SetValue(DBM.Options.SpecialWarningFlashCount5)
 	end
 	DBM:UpdateSpecialWarningOptions()
+	DBM:RefreshSpellRenames()
 end)

--- a/DBM-GUI/modules/options/timers/Behavior.lua
+++ b/DBM-GUI/modules/options/timers/Behavior.lua
@@ -41,7 +41,10 @@ HiddenBarsToggle:SetPoint("TOPLEFT", DecimalSlider, "BOTTOMLEFT", 0, -65)
 
 BarBehaviors:CreateCheckButton(L.ClickThrough, true, nil, nil, "ClickThrough")
 BarBehaviors:CreateCheckButton(L.DisableRightClickBar, true, nil, nil, "DisableRightClick")
-BarBehaviors:CreateCheckButton(L.ShortTimerText, true, nil, "ShortTimerText")
+local shortTimerText = BarBehaviors:CreateCheckButton(L.ShortTimerText, true, nil, "ShortTimerText")
+shortTimerText:HookScript("OnClick", function()
+	DBM:RefreshSpellRenames()
+end)
 BarBehaviors:CreateCheckButton(L.KeepBar, true, nil, nil, "KeepBars")
 if not DBM:IsPostMidnight() then
 	--Only option we can't restore even with mod hardcodes


### PR DESCRIPTION
 - Turning off renames now turns them off without requiring uireload
 - Turning off renames on timers is now honored.