### PR TITLE
Reduce idle cost for optional DBM-Core features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,31 @@ jobs:
           status: ${{ job.status }}
         if: ${{ failure() }}
 
+  test-package:
+    name: Test Package
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    needs:
+      - test
+
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Create test package
+        uses: BigWigsMods/packager@master
+        with:
+          args: -d
+          pandoc: false
+      - name: Upload test packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: DBM-Retail-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          path: .release/*.zip
+          if-no-files-found: error
+          retention-days: 14
+
   deploy:
     name: Deployment
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     needs:
       - test
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Checkout pull request
@@ -63,12 +66,53 @@ jobs:
           mkdir -p artifacts
           cp .release/*.zip artifacts/
       - name: Upload test packages
-        uses: actions/upload-artifact@v4
+        id: upload-test-packages
+        uses: actions/upload-artifact@v7
         with:
           name: DBM-Retail-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           path: artifacts/*.zip
           if-no-files-found: error
           retention-days: 14
+      - name: Link test package on pull request
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: actions/github-script@v8
+        env:
+          ARTIFACT_URL: ${{ steps.upload-test-packages.outputs.artifact-url }}
+        with:
+          script: |
+            const marker = '<!-- dbm-retail-test-package -->';
+            const body = [
+              marker,
+              '## DBM-Retail test package',
+              '',
+              `[Download the packaged test ZIPs](${process.env.ARTIFACT_URL})`,
+              '',
+              'This artifact includes packager-fetched dependencies and substitutions. It expires after 14 days.',
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            });
+            const existingComment = comments.find((comment) => comment.body.includes(marker));
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
 
   deploy:
     name: Deployment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
 
     steps:
       - name: Checkout pull request
@@ -79,6 +80,7 @@ jobs:
         env:
           ARTIFACT_URL: ${{ steps.upload-test-packages.outputs.artifact-url }}
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const marker = '<!-- dbm-retail-test-package -->';
             const body = [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,16 @@ jobs:
         with:
           args: -d
           pandoc: false
+      - name: Stage test packages
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          cp .release/*.zip artifacts/
       - name: Upload test packages
         uses: actions/upload-artifact@v4
         with:
           name: DBM-Retail-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
-          path: .release/*.zip
+          path: artifacts/*.zip
           if-no-files-found: error
           retention-days: 14
 

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -79,7 +79,7 @@ end
 DBM.Revision = parseCurseDate("@project-date-integer@")
 DBM.TaintedByTests = false -- Tests may mess with some internal state, you probably don't want to rely on DBM for an important boss fight after running it in test mode
 
-private.fakeBWVersion, private.fakeBWHash = 416, "1888a1e"--416.0
+private.fakeBWVersion, private.fakeBWHash = 424, "754bdce"--424.7
 
 -- The string that is shown as version
 DBM.DisplayVersion = "12.1.10 alpha"--Core version

--- a/DBM-Core/DBM-Core_Mainline.toc
+++ b/DBM-Core/DBM-Core_Mainline.toc
@@ -86,7 +86,7 @@ DBM-Flash.lua
 DBM-RangeCheck.lua
 DBM-InfoFrame.lua
 DBM-HudMap.lua
-DBM-Nameplate.lua
+DBM-Nameplate-Mainline.lua
 
 # GUI Features
 modules\gui\Gear.lua

--- a/DBM-Core/DBM-Nameplate-Mainline.lua
+++ b/DBM-Core/DBM-Nameplate-Mainline.lua
@@ -1,0 +1,30 @@
+---@diagnostic disable: duplicate-set-field -- Mutually exclusive with DBM-Nameplate.lua in client-specific TOCs.
+
+---@class DBM
+local DBM = DBM
+
+-- Nameplate rendering is unavailable in Midnight content. Keep the public API so
+-- older modules and third-party callers can remain version-agnostic without
+-- loading the Classic renderer, creating frames, or registering callbacks.
+---@class DBMNameplateFrame
+local nameplateFrame = {}
+DBM.Nameplate = nameplateFrame
+
+function nameplateFrame:Show()
+end
+
+function nameplateFrame:Hide()
+end
+
+function nameplateFrame:IsShown()
+	return false
+end
+
+function nameplateFrame:UpdateIconOptions()
+end
+
+function nameplateFrame:ValidateFontSettings()
+end
+
+function DBM.PauseTestTimer()
+end

--- a/DBM-Core/DBM-Nameplate.lua
+++ b/DBM-Core/DBM-Nameplate.lua
@@ -17,7 +17,7 @@ local GetNamePlateForUnit, GetNamePlates = C_NamePlate.GetNamePlateForUnit, C_Na
 local twipe, floor, strsub, strbyte= table.wipe, math.floor, _G.strsub, _G.strbyte
 local CooldownFrame_Set = CooldownFrame_Set
 --function locals
-local NameplateIcon_Hide, Nameplate_UnitAdded, CreateAuraFrame
+local NameplateIcon_Hide, Nameplate_UnitAdded, CreateAuraFrame, CreateRootFrame
 
 ---@class DBMNameplate: Frame, NamePlateBaseMixin
 ---@field DBMAuraFrame DBMAuraFrame
@@ -82,9 +82,8 @@ end
 --------------------
 --  Create Frame  --
 --------------------
-local DBMNameplateFrame = CreateFrame("Frame", "DBMNameplate", UIParent)
-DBMNameplateFrame:SetFrameStrata('BACKGROUND')
-DBMNameplateFrame:Hide()
+---@type Frame?
+local DBMNameplateFrame
 
 ----------------------
 -- Helper functions --
@@ -136,7 +135,7 @@ do
 	local function AuraFrame_CreateIcon(frame)
 		-- base frame
 		---@class DBMNamePlateIconFrame: Button, BackdropTemplate
-		local iconFrame = CreateFrame("Button", "DBMNameplateAI" .. #frame.icons, DBMNameplateFrame, "BackdropTemplate")
+		local iconFrame = CreateFrame("Button", "DBMNameplateAI" .. #frame.icons, CreateRootFrame(), "BackdropTemplate")
 		iconFrame:EnableMouse(false)
 		iconFrame:SetBackdrop({edgeFile = [[Interface\Buttons\WHITE8X8]], edgeSize = 1})
 		iconFrame:Hide()
@@ -374,6 +373,10 @@ do
 		if not iconFrame then return end
 
 		iconFrame:SetScript("OnUpdate", nil)
+		if iconFrame.isGlowing then
+			frame:StopGlow(iconFrame, iconFrame.isGlowing)
+			iconFrame.isGlowing = false
+		end
 		iconFrame:Hide()
 		frame.texture_index[index] = nil
 
@@ -391,6 +394,9 @@ do
 		twipe(frame.texture_index)
 	end
 	local function AuraFrame_StartGlow(self, iconFrame, glowType)
+		if not LCG then
+			return false
+		end
 		local aura_tbl = iconFrame.aura_tbl
 		iconFrame.__DBM_NPIconGlowFrame:Show()
 		if glowType == 1 then--Pixel
@@ -437,9 +443,13 @@ do
 			}
 			LCG.ButtonGlow_Start(iconFrame.__DBM_NPIconGlowFrame, options.color, options.frequency)--This one doesn't use a key
 		end
+		return true
 	end
 	local function AuraFrame_StopGlow(self, iconFrame, glowType)
-		if glowType == 1 then
+		if not LCG then
+			iconFrame.__DBM_NPIconGlowFrame:Hide()
+			return
+		elseif glowType == 1 then
 			LCG.PixelGlow_Stop(iconFrame.__DBM_NPIconGlowFrame, "DBM_ImportantMinDurationGlow")
 		elseif glowType == 2 then
 			LCG.ProcGlow_Stop(iconFrame.__DBM_NPIconGlowFrame, "DBM_ImportantMinDurationGlow")
@@ -480,9 +490,10 @@ do
 			end
 			local glowType = aura_tbl.barType == "castnp" and DBM.Options.CastNPIconGlowType2 or DBM.Options.CDNPIconGlowType
 			if canGlow and not self.isGlowing then
-				self.parent:StartGlow(self, glowType)
-				self.isGlowing = glowType
-			elseif not canGlow and self.isGlowing ~= false or aura_tbl.remaining < 0 then
+				if self.parent:StartGlow(self, glowType) then
+					self.isGlowing = glowType
+				end
+			elseif self.isGlowing and (not canGlow or aura_tbl.remaining < 0) then
 				self.parent:StopGlow(self, self.isGlowing)
 				self.isGlowing = false
 			end
@@ -570,9 +581,10 @@ local function NameplateIcon_Show(isGUID, unit, aura_tbl)
 	if not unit or not aura_tbl then return end
 
 	--Not running supported NP Mod, internal handling
-	if not DBMNameplateFrame:IsShown() then
-		DBMNameplateFrame:Show()
-		DBMNameplateFrame:RegisterEvent("NAME_PLATE_UNIT_ADDED")
+	local rootFrame = CreateRootFrame()
+	if not rootFrame:IsShown() then
+		rootFrame:Show()
+		rootFrame:RegisterEvent("NAME_PLATE_UNIT_ADDED")
 		DBM:Debug("DBM.Nameplate Enabling", 2)
 	end
 
@@ -664,8 +676,10 @@ function NameplateIcon_Hide(isGUID, unit, index, force)
 		twipe(units)
 		num_units = 0
 
-		DBMNameplateFrame:UnregisterEvent("NAME_PLATE_UNIT_ADDED")
-		DBMNameplateFrame:Hide()
+		if DBMNameplateFrame then
+			DBMNameplateFrame:UnregisterEvent("NAME_PLATE_UNIT_ADDED")
+			DBMNameplateFrame:Hide()
+		end
 		DBM:Debug("DBM.Nameplate Disabling", 2)
 	end
 end
@@ -707,16 +721,25 @@ end
 ----------------
 --  On Event  --
 ----------------
-DBMNameplateFrame:SetScript("OnEvent", function(_, event, ...)
-	if event == 'NAME_PLATE_UNIT_ADDED' then
-		local unit = ...
-		if not unit then return end
-		local f = GetNamePlateForUnit(unit)
-		if not f then return end
-
-		Nameplate_UnitAdded(f,unit)
+function CreateRootFrame()
+	if DBMNameplateFrame then
+		return DBMNameplateFrame
 	end
-end)
+	DBMNameplateFrame = CreateFrame("Frame", "DBMNameplate", UIParent)
+	DBMNameplateFrame:SetFrameStrata('BACKGROUND')
+	DBMNameplateFrame:Hide()
+	DBMNameplateFrame:SetScript("OnEvent", function(_, event, ...)
+		if event == 'NAME_PLATE_UNIT_ADDED' then
+			local unit = ...
+			if not unit then return end
+			local f = GetNamePlateForUnit(unit)
+			if not f then return end
+
+			Nameplate_UnitAdded(f,unit)
+		end
+	end)
+	return DBMNameplateFrame
+end
 
 --------------------------------------
 --  Nameplate Timer Icons Registry  --

--- a/DBM-Core/DBM-RangeCheck.lua
+++ b/DBM-Core/DBM-RangeCheck.lua
@@ -28,9 +28,9 @@ local function UnitPhaseReasonHack(uId)
 end
 
 local L = DBM_CORE_L
----@class DBMRangeCheckFrame: Frame
-local mainFrame = CreateFrame("Frame")
-local textFrame, radarFrame, updateIcon, updateRangeFrame, initializeDropdown, initializeDropdownLegacy
+local mainFrame = {}
+local controllerFrame, updater
+local textFrame, radarFrame, updateIcon, updateRangeFrame, initializeDropdown, initializeDropdownLegacy, createController
 local RAID_CLASS_COLORS = _G["CUSTOM_CLASS_COLORS"] or RAID_CLASS_COLORS -- For Phanx' Class Colors
 
 -- Function for automatically converting inputed ranges from old mods to be ones that have valid item/api checks
@@ -579,7 +579,7 @@ do
 	local UnitExists, UnitIsUnit, UnitIsDeadOrGhost, UnitIsConnected, GetPlayerFacing, UnitClass, IsInRaid, GetNumGroupMembers, GetRaidTargetIndex, GetBestMapForUnit = UnitExists, UnitIsUnit, UnitIsDeadOrGhost, UnitIsConnected, GetPlayerFacing, UnitClass, IsInRaid, GetNumGroupMembers, GetRaidTargetIndex, C_Map.GetBestMapForUnit
 	local max, min, sin, cos, pi2 = math.max, math.min, math.sin, math.cos, math.pi * 2
 	local circleColor, rotation, pixelsperyard, activeDots, prevRange, prevThreshold, prevNumClosePlayer, prevclosestRange, prevColor, prevType = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-	local unitList = {}
+	local unitList, unitClasses, unitIcons = {}, {}, {}
 	local BLIP_TEX_COORDS = {
 		["WARRIOR"]		= { 0, 0.125, 0, 0.25 },
 		["PALADIN"]		= { 0.125, 0.25, 0, 0.25 },
@@ -611,28 +611,35 @@ do
 		local numPlayers = GetNumGroupMembers() or 0
 		activeDots = max(numPlayers, activeDots)
 		for i = 1, activeDots do
-			local dot = radarFrame.dots[i]
 			if i <= numPlayers then
 				unitList[i] = IsInRaid() and "raid" .. i or "party" .. i
 				local _, class = UnitClass(unitList[i])
 				local icon = GetRaidTargetIndex(unitList[i])
-				dot.class = class
-				if icon and icon < 9 then
-					dot.icon = icon
-					dot:SetTexture(13700 .. icon) -- "Interface\\TargetingFrame\\UI-RaidTargetingIcon_" .. icon
-					dot:SetTexCoord(0, 1, 0, 1)
-					dot:SetSize(16, 16)
-					dot:SetDrawLayer("OVERLAY", 1)
-				else
-					dot.icon = nil
-					class = class or "PRIEST"
-					dot:SetTexture(249183) -- "Interface\\Minimap\\PartyRaidBlips"
-					dot:SetTexCoord(BLIP_TEX_COORDS[class][1], BLIP_TEX_COORDS[class][2], BLIP_TEX_COORDS[class][3], BLIP_TEX_COORDS[class][4])
-					dot:SetSize(24, 24)
-					dot:SetDrawLayer("OVERLAY", 0)
+				unitClasses[i] = class
+				unitIcons[i] = icon and icon < 9 and icon or nil
+				if radarFrame then
+					local dot = radarFrame.dots[i]
+					dot.class = class
+					if unitIcons[i] then
+						dot.icon = unitIcons[i]
+						dot:SetTexture(13700 .. unitIcons[i]) -- "Interface\\TargetingFrame\\UI-RaidTargetingIcon_" .. icon
+						dot:SetTexCoord(0, 1, 0, 1)
+						dot:SetSize(16, 16)
+						dot:SetDrawLayer("OVERLAY", 1)
+					else
+						dot.icon = nil
+						class = class or "PRIEST"
+						dot:SetTexture(249183) -- "Interface\\Minimap\\PartyRaidBlips"
+						dot:SetTexCoord(BLIP_TEX_COORDS[class][1], BLIP_TEX_COORDS[class][2], BLIP_TEX_COORDS[class][3], BLIP_TEX_COORDS[class][4])
+						dot:SetSize(24, 24)
+						dot:SetDrawLayer("OVERLAY", 0)
+					end
 				end
-			elseif dot:IsShown() then
-				dot:Hide()
+			else
+				unitList[i], unitClasses[i], unitIcons[i] = nil, nil, nil
+				if radarFrame and radarFrame.dots[i]:IsShown() then
+					radarFrame.dots[i]:Hide()
+				end
 			end
 		end
 	end
@@ -644,8 +651,8 @@ do
 		end
 		local activeRange = mainFrame.range
 		local restricted = mainFrame.restrictions
-		local tEnabled = textFrame:IsShown()
-		local rEnabled = radarFrame:IsShown()
+		local tEnabled = textFrame and textFrame:IsShown()
+		local rEnabled = radarFrame and radarFrame:IsShown()
 		local reverse = mainFrame.reverse
 		local warnThreshold = mainFrame.redCircleNumPlayers
 		if tEnabled then
@@ -692,7 +699,7 @@ do
 		local onlySummary = mainFrame.onlySummary
 		for i = 1, GetNumGroupMembers() do
 			local uId = unitList[i]
-			local dot = radarFrame.dots[i]
+			local dot = radarFrame and radarFrame.dots[i]
 			local mapId = GetBestMapForUnit(uId) or 0
 			if UnitExists(uId) and playerMapId == mapId and not UnitIsUnit(uId, "player") and not UnitIsDeadOrGhost(uId) and UnitIsConnected(uId) and UnitPhaseReasonHack(uId) and (not filter or filter(uId)) then
 				local range = restricted and itsBCAgain(uId, activeRange) or UnitDistanceSquared(uId) ^ 0.5
@@ -715,8 +722,8 @@ do
 				if tEnabled and inRange and not onlySummary and closePlayer < 6 then -- Display up to 5 players in text range frame.
 					local playerName = DBM:GetUnitFullName(uId)
 					playerName = DBM:GetShortServerName(playerName)
-					local color = RAID_CLASS_COLORS[dot.class] or NORMAL_FONT_COLOR
-					textFrame.lines[closePlayer]:SetText(dot.icon and ("|TInterface\\TargetingFrame\\UI-RaidTargetingIcon_%d:0|t %s"):format(dot.icon, playerName) or playerName)
+					local color = RAID_CLASS_COLORS[unitClasses[i]] or NORMAL_FONT_COLOR
+					textFrame.lines[closePlayer]:SetText(unitIcons[i] and ("|TInterface\\TargetingFrame\\UI-RaidTargetingIcon_%d:0|t %s"):format(unitIcons[i], playerName) or playerName)
 					textFrame.lines[closePlayer]:SetTextColor(color.r, color.g, color.b)
 					textFrame.lines[closePlayer]:Show()
 					textFrame:SetHeight((closePlayer * 12) + 12)
@@ -791,17 +798,25 @@ do
 	end
 end
 
-local updater = mainFrame:CreateAnimationGroup()
-updater:SetLooping("REPEAT")
-local anim = updater:CreateAnimation()
-anim:SetDuration(0.05)
-
-mainFrame:SetSize(0, 0)
-mainFrame:SetScript("OnEvent", function(self, event)
-	if event == "GROUP_ROSTER_UPDATE" or event == "RAID_TARGET_UPDATE" then
-		updateIcon()
+function createController()
+	if controllerFrame then
+		return controllerFrame
 	end
-end)
+	controllerFrame = CreateFrame("Frame")
+	controllerFrame:SetSize(0, 0)
+	controllerFrame:SetScript("OnEvent", function(_, event)
+		if event == "GROUP_ROSTER_UPDATE" or event == "RAID_TARGET_UPDATE" then
+			updateIcon()
+		elseif event == "PLAYER_REGEN_DISABLED" and IsInInstance() then
+			rangeCheck:Hide(true)
+		end
+	end)
+	updater = controllerFrame:CreateAnimationGroup()
+	updater:SetLooping("REPEAT")
+	local anim = updater:CreateAnimation()
+	anim:SetDuration(0.05)
+	return controllerFrame
+end
 
 ---------------
 --  Methods  --
@@ -814,7 +829,7 @@ function rangeCheck:Show(range, filter, forceshow, redCircleNumPlayers, reverse,
 	end
 	DBM:UpdateMapRestrictions()--Probably redundant but one place I feel good about a redundant call. this isn't something that spams like an update handler
 	local restrictionsActive = DBM:HasMapRestrictions()
-	if restrictionsActive then--Don't popup on retail or classic era at all if in an instance (it now only works in wrath)
+	if restrictionsActive and InCombatLockdown() then
 		return
 	end
 	if type(range) == "function" then -- The first argument is optional
@@ -822,20 +837,27 @@ function rangeCheck:Show(range, filter, forceshow, redCircleNumPlayers, reverse,
 	end
 	range = range or 10
 	redCircleNumPlayers = redCircleNumPlayers or 1
-	if not textFrame then
+	local showText = DBM.Options.RangeFrameFrames == "text" or DBM.Options.RangeFrameFrames == "both" or restrictionsActive
+	local showRadar = not restrictionsActive and (DBM.Options.RangeFrameFrames == "radar" or DBM.Options.RangeFrameFrames == "both")
+	if showText and not textFrame then
 		createTextFrame()
 	end
-	if not radarFrame then
+	if showRadar and not radarFrame then
 		createRadarFrame()
 	end
 	if restrictionsActive then
 		range = setCompatibleRestrictedRange(range)
 	end
-	if (DBM.Options.RangeFrameFrames == "text" or DBM.Options.RangeFrameFrames == "both" or restrictionsActive) and not textFrame:IsShown() then
+	if textFrame then
+		textFrame:Hide()
+	end
+	if radarFrame then
+		radarFrame:Hide()
+	end
+	if showText then
 		textFrame:Show()
 	end
-	-- TODO, add check for restricted area here so we can prevent radar frame loading.
-	if not restrictionsActive and (DBM.Options.RangeFrameFrames == "radar" or DBM.Options.RangeFrameFrames == "both") and not radarFrame:IsShown() then
+	if showRadar then
 		radarFrame:Show()
 	end
 	mainFrame.range = range
@@ -845,11 +867,13 @@ function rangeCheck:Show(range, filter, forceshow, redCircleNumPlayers, reverse,
 	mainFrame.hideTime = hideTime and (GetTime() + hideTime) or 0
 	mainFrame.restrictions = restrictionsActive
 	mainFrame.onlySummary = onlySummary
+	local eventFrame = createController()
 	if not mainFrame.eventRegistered then
 		mainFrame.eventRegistered = true
 		updateIcon()
-		mainFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
-		mainFrame:RegisterEvent("RAID_TARGET_UPDATE")
+		eventFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
+		eventFrame:RegisterEvent("RAID_TARGET_UPDATE")
+		eventFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
 	end
 	updater:SetScript("OnLoop", updateRangeFrame)
 	updater:Play()
@@ -863,10 +887,15 @@ function rangeCheck:Hide(force)
 		rangeCheck:Show(restoreRange, restoreFilter, true, restoreThreshold, restoreReverse)
 	else
 		restoreRange, restoreFilter, restoreThreshold, restoreReverse = nil, nil, nil, nil
-		updater:Stop()
+		if updater then
+			updater:Stop()
+			updater:SetScript("OnLoop", nil)
+		end
 		if mainFrame.eventRegistered then
 			mainFrame.eventRegistered = nil
-			mainFrame:UnregisterAllEvents()
+			controllerFrame:UnregisterEvent("GROUP_ROSTER_UPDATE")
+			controllerFrame:UnregisterEvent("RAID_TARGET_UPDATE")
+			controllerFrame:UnregisterEvent("PLAYER_REGEN_DISABLED")
 		end
 		if textFrame then
 			textFrame:Hide()
@@ -888,7 +917,7 @@ end
 function rangeCheck:UpdateRestrictions(force)
 	DBM:UpdateMapRestrictions()
 	mainFrame.restrictions = force or DBM:HasMapRestrictions()
-	if mainFrame.restrictions then
+	if mainFrame.restrictions and InCombatLockdown() then
 		rangeCheck:Hide(true)
 	end
 end
@@ -925,7 +954,7 @@ do
 	SLASH_DBMRRANGE2 = "/rdistance"
 	SlashCmdList["DBMRANGE"] = function(msg)
 		DBM:UpdateMapRestrictions()
-		if DBM:HasMapRestrictions() then
+		if DBM:HasMapRestrictions() and InCombatLockdown() then
 			DBM:AddMsg(L.NO_RANGE)
 		else
 			UpdateLocalRangeFrame(tonumber(msg))
@@ -933,7 +962,7 @@ do
 	end
 	SlashCmdList["DBMRRANGE"] = function(msg)
 		DBM:UpdateMapRestrictions()
-		if DBM:HasMapRestrictions() then
+		if DBM:HasMapRestrictions() and InCombatLockdown() then
 			DBM:AddMsg(L.NO_RANGE)
 		else
 			UpdateLocalRangeFrame(tonumber(msg), true)

--- a/DBM-Core/modules/gui/BattleRezTimer.lua
+++ b/DBM-Core/modules/gui/BattleRezTimer.lua
@@ -39,6 +39,9 @@ end
 ---------------------------------------
 local ApplyFont
 local function CreateDisplayFrame()
+	if frame then
+		return frame
+	end
 	frame = CreateFrame("Frame", "DBMBattleRezTimerFrame", UIParent, "BackdropTemplate")
 	frame:SetSize(140, 30)
 	frame:SetClampedToScreen(true)
@@ -94,6 +97,7 @@ local function CreateDisplayFrame()
 	end)
 
 	ApplyFont()
+	return frame
 end
 
 local function ApplyPosition()
@@ -186,11 +190,12 @@ do
 			lastCharges = -1
 			-- Cancel any preview auto-hide timer now that combat has started
 			CancelPreviewTimer()
-			if DBM.Options.ShowBrezFrame and frame then
+			if DBM.Options.ShowBrezFrame then
+				local displayFrame = CreateDisplayFrame()
 				ApplyPosition()
-				frame:EnableMouse(false)
-				frame.header:Hide()
-				frame:Show()
+				displayFrame:EnableMouse(false)
+				displayFrame.header:Hide()
+				displayFrame:Show()
 			end
 		end
 
@@ -300,8 +305,6 @@ do
 	end
 end
 
-CreateDisplayFrame()
-
 ---------------------------------------
 -- Public API
 ---------------------------------------
@@ -312,15 +315,15 @@ end
 
 --- Show the frame for manual positioning (out of combat preview)
 function BattleRezTimer:Show()
-	if not frame then return end
 	-- When in active combat, respect the ShowBrezFrame option
 	if chargesActive and not DBM.Options.ShowBrezFrame then
 		return
 	end
+	local displayFrame = CreateDisplayFrame()
 
 	-- Out-of-combat preview: toggle visibility
 	if not chargesActive then
-		if frame:IsShown() then
+		if displayFrame:IsShown() then
 			CancelPreviewTimer()
 			self:Hide()
 			return
@@ -333,17 +336,17 @@ function BattleRezTimer:Show()
 
 	-- Unlock for positioning when in preview (out of combat)
 	if not chargesActive then
-		frame:EnableMouse(true)
-		frame.header:Show()
-		frame.charges:SetText("0")
-		frame.charges:SetTextColor(1, 1, 1)
-		frame.timer:SetText("0:00")
+		displayFrame:EnableMouse(true)
+		displayFrame.header:Show()
+		displayFrame.charges:SetText("0")
+		displayFrame.charges:SetTextColor(1, 1, 1)
+		displayFrame.timer:SetText("0:00")
 	else
-		frame:EnableMouse(false)
-		frame.header:Hide()
+		displayFrame:EnableMouse(false)
+		displayFrame.header:Hide()
 	end
 
-	frame:Show()
+	displayFrame:Show()
 
 	-- Auto-hide preview after 15 seconds if still out of combat
 	if not chargesActive then

--- a/DBM-Core/modules/gui/Durability.lua
+++ b/DBM-Core/modules/gui/Durability.lua
@@ -24,50 +24,10 @@ if not LibDurability then
 	return
 end
 
-local frame = CreateFrame("Frame", "DBMDurabilityFrame", UIParent, "DefaultPanelTemplate") --[[@as DefaultPanelTemplate]]
-tinsert(_G["UISpecialFrames"], frame:GetName())
-frame:Hide()
-frame:SetSize(380, 300)
-frame:SetClampedToScreen(true)
-frame:SetPoint("LEFT")
-frame:SetFrameStrata("DIALOG")
-frame:SetMovable(true)
-frame:EnableMouse(true)
-frame:RegisterForDrag("LeftButton")
-frame:SetTitle(L.DUR_HEADER)
-frame:SetScript("OnDragStart", frame.StartMoving)
-frame:SetScript("OnDragStop", function(self)
-	self:StopMovingOrSizing()
-	local point, _, _, x, y = self:GetPoint(1)
-	DBM.Options.DurabilityPosition = {point, x, y}
-end)
-
-frame.Bg:SetTexture("Interface\\FrameGeneral\\UI-Background-Rock")
-frame.Bg:SetColorTexture(0, 0, 0, 0.8)
-
-local closeBtn = CreateFrame("Button", nil, frame, "UIPanelCloseButtonDefaultAnchors")
-closeBtn:SetFrameLevel(frame.NineSlice:GetFrameLevel() + 10)
-
-local scroll = CreateFrame("ScrollFrame", nil, frame, "ScrollFrameTemplate")
-scroll:SetPoint("TOPLEFT", frame, "TOPLEFT", 8, -30)
-scroll:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -24, 30)
-
-local child = CreateFrame("Frame", nil, scroll)
-scroll:SetScrollChild(child)
-child:SetSize(scroll:GetWidth(), scroll:GetHeight())
-child:SetPoint("LEFT")
-
-local refresh = CreateFrame("Button", nil, frame)
-refresh:SetSize(20, 20)
-refresh:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 8, 6)
-refresh:SetText("REFRESH")
-refresh:Show()
-refresh:SetNormalTexture("Interface\\Buttons\\UI-RefreshButton")
-refresh:SetPushedTexture("Interface\\Buttons\\UI-RefreshButton-Down")
-refresh:SetHighlightTexture("Interface\\Buttons\\UI-RefreshButton")
-refresh:SetScript("OnClick", function()
-	LibDurability:RequestDurability()
-end)
+---@type DefaultPanelTemplate?
+local frame
+local scroll, child, titlePlayer, titlePercent, titleBroken
+local percentWidth, brokenWidth
 
 -- Frames handler
 local spareTextFrames, usedTextFrames = {}, {}
@@ -102,38 +62,91 @@ local function GetTextFrame()
 	return _frame
 end
 
-local titlePlayer = GetTextFrame()
-titlePlayer.Keep = true
-titlePlayer:SetFontObject(GameFontNormalLarge)
-titlePlayer:SetText(PLAYER)
-titlePlayer:SetPoint("TOPLEFT", child, 7, 0)
-titlePlayer:SetWidth(120)
+local function CreateFrame()
+	if frame then
+		return frame
+	end
+	frame = _G.CreateFrame("Frame", "DBMDurabilityFrame", UIParent, "DefaultPanelTemplate") --[[@as DefaultPanelTemplate]]
+	tinsert(_G["UISpecialFrames"], frame:GetName())
+	frame:Hide()
+	frame:SetSize(380, 300)
+	frame:SetClampedToScreen(true)
+	frame:SetPoint("LEFT")
+	frame:SetFrameStrata("DIALOG")
+	frame:SetMovable(true)
+	frame:EnableMouse(true)
+	frame:RegisterForDrag("LeftButton")
+	frame:SetTitle(L.DUR_HEADER)
+	frame:SetScript("OnDragStart", frame.StartMoving)
+	frame:SetScript("OnDragStop", function(self)
+		self:StopMovingOrSizing()
+		local point, _, _, x, y = self:GetPoint(1)
+		DBM.Options.DurabilityPosition = {point, x, y}
+	end)
 
-local titlePercent = GetTextFrame()
-titlePercent.Keep = true
-titlePercent:SetFontObject(GameFontNormalLarge)
-titlePercent:SetText("%")
-titlePercent:SetPoint("LEFT", titlePlayer, "RIGHT", 0, 0)
+	frame.Bg:SetTexture("Interface\\FrameGeneral\\UI-Background-Rock")
+	frame.Bg:SetColorTexture(0, 0, 0, 0.8)
 
-local titleBroken = GetTextFrame()
-titleBroken.Keep = true
-titleBroken:SetFontObject(GameFontNormalLarge)
-titleBroken:SetText(TUTORIAL_TITLE37)
-titleBroken:SetPoint("LEFT", titlePercent, "RIGHT")
+	local closeBtn = _G.CreateFrame("Button", nil, frame, "UIPanelCloseButtonDefaultAnchors")
+	closeBtn:SetFrameLevel(frame.NineSlice:GetFrameLevel() + 10)
 
-local percentWidth, brokenWidth = mmax(75, titlePercent:GetStringWidth() + 20), mmax(75, titleBroken:GetStringWidth() + 20)
-titlePercent:SetWidth(percentWidth)
-titleBroken:SetWidth(brokenWidth)
+	scroll = _G.CreateFrame("ScrollFrame", nil, frame, "ScrollFrameTemplate")
+	scroll:SetPoint("TOPLEFT", frame, "TOPLEFT", 8, -30)
+	scroll:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -24, 30)
 
--- Update main frame width
-child:SetWidth(120 + percentWidth + brokenWidth + 8)
-frame:SetWidth(child:GetWidth() + 32)
+	child = _G.CreateFrame("Frame", nil, scroll)
+	scroll:SetScrollChild(child)
+	child:SetSize(scroll:GetWidth(), scroll:GetHeight())
+	child:SetPoint("LEFT")
+
+	local refresh = _G.CreateFrame("Button", nil, frame)
+	refresh:SetSize(20, 20)
+	refresh:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 8, 6)
+	refresh:SetText("REFRESH")
+	refresh:Show()
+	refresh:SetNormalTexture("Interface\\Buttons\\UI-RefreshButton")
+	refresh:SetPushedTexture("Interface\\Buttons\\UI-RefreshButton-Down")
+	refresh:SetHighlightTexture("Interface\\Buttons\\UI-RefreshButton")
+	refresh:SetScript("OnClick", function()
+		LibDurability:RequestDurability()
+	end)
+
+	titlePlayer = GetTextFrame()
+	titlePlayer.Keep = true
+	titlePlayer:SetFontObject(GameFontNormalLarge)
+	titlePlayer:SetText(PLAYER)
+	titlePlayer:SetPoint("TOPLEFT", child, 7, 0)
+	titlePlayer:SetWidth(120)
+
+	titlePercent = GetTextFrame()
+	titlePercent.Keep = true
+	titlePercent:SetFontObject(GameFontNormalLarge)
+	titlePercent:SetText("%")
+	titlePercent:SetPoint("LEFT", titlePlayer, "RIGHT", 0, 0)
+
+	titleBroken = GetTextFrame()
+	titleBroken.Keep = true
+	titleBroken:SetFontObject(GameFontNormalLarge)
+	titleBroken:SetText(TUTORIAL_TITLE37)
+	titleBroken:SetPoint("LEFT", titlePercent, "RIGHT")
+
+	percentWidth, brokenWidth = mmax(75, titlePercent:GetStringWidth() + 20), mmax(75, titleBroken:GetStringWidth() + 20)
+	titlePercent:SetWidth(percentWidth)
+	titleBroken:SetWidth(brokenWidth)
+
+	child:SetWidth(120 + percentWidth + brokenWidth + 8)
+	frame:SetWidth(child:GetWidth() + 32)
+	return frame
+end
 
 local function SortDurability(v1, v2)
 	return (v1.durpercent or 9999) < (v2.durpercent or 9999)
 end
 
 local function Update()
+	if not frame or not frame:IsShown() then
+		return
+	end
 	local sortDur = {}
 	for _, v in pairs(DBM:GetRaidRoster()) do
 		tinsert(sortDur, v)
@@ -192,15 +205,19 @@ function Durability:Show()
 		DBM.GearCheck:Hide()
 	end
 	DBM.Latency:Hide()
-	LibDurability:RequestDurability()
+	local displayFrame = CreateFrame()
 	if _G["DBM_GUI_OptionsFrame"] then
-		frame:SetFrameLevel(_G["DBM_GUI_OptionsFrame"]:GetFrameLevel() + 10)
+		displayFrame:SetFrameLevel(_G["DBM_GUI_OptionsFrame"]:GetFrameLevel() + 10)
 	end
-	frame:ClearAllPoints()
-	frame:SetPoint(DBM.Options.DurabilityPosition[1], DBM.Options.DurabilityPosition[2], DBM.Options.DurabilityPosition[3])
-	frame:Show()
+	displayFrame:ClearAllPoints()
+	displayFrame:SetPoint(DBM.Options.DurabilityPosition[1], DBM.Options.DurabilityPosition[2], DBM.Options.DurabilityPosition[3])
+	displayFrame:Show()
+	Update()
+	LibDurability:RequestDurability()
 end
 
 function Durability:Hide()
-	frame:Hide()
+	if frame then
+		frame:Hide()
+	end
 end

--- a/DBM-Core/modules/gui/Gear.lua
+++ b/DBM-Core/modules/gui/Gear.lua
@@ -13,30 +13,10 @@ local tinsert, tremove, tsort, mmax, mfloor = table.insert, table.remove, table.
 local L = DBM_CORE_L
 local RAID_CLASS_COLORS = _G["CUSTOM_CLASS_COLORS"] or RAID_CLASS_COLORS-- for Phanx' Class Colors
 
----@class DBMGearCheckFrame: DefaultPanelTemplate
-local frame = CreateFrame("Frame", "DBMGearCheckFrame", UIParent, "DefaultPanelTemplate") --[[@as DefaultPanelTemplate]]
-tinsert(_G["UISpecialFrames"], frame:GetName())
-frame:Hide()
-frame:SetSize(380, 300)
-frame:SetClampedToScreen(true)
-frame:SetPoint("LEFT")
-frame:SetFrameStrata("DIALOG")
-frame:SetMovable(true)
-frame:EnableMouse(true)
-frame:RegisterForDrag("LeftButton")
-frame:SetTitle(L.GEAR_HEADER)
-frame:SetScript("OnDragStart", frame.StartMoving)
-frame:SetScript("OnDragStop", function(self)
-	self:StopMovingOrSizing()
-	local point, _, _, x, y = self:GetPoint(1)
-	DBM.Options.GearPosition = {point, x, y}
-end)
-
-frame.Bg:SetTexture("Interface\\FrameGeneral\\UI-Background-Rock")
-frame.Bg:SetColorTexture(0, 0, 0, 0.8)
-
-local closeBtn = CreateFrame("Button", nil, frame, "UIPanelCloseButtonDefaultAnchors")
-closeBtn:SetFrameLevel(frame.NineSlice:GetFrameLevel() + 10)
+---@type DefaultPanelTemplate?
+local frame
+local scroll, child, titlePlayer, titleItemLevel, titleMissingGems, titleMissingEnchants
+local playerWidth, itemLevelWidth, missingGemsWidth, missingEnchantsWidth
 
 local spareTextFrames, usedTextFrames = {}, {}
 local pendingInspects = {}
@@ -75,60 +55,40 @@ local validAnchorPoints = {
 
 local tabs, tabsBtn, selectedTab = {}, {}, 1
 
-local WipeTextFrames, Refresh, SendGuildGearSyncRequest, ShouldUseCommScan, RequestNextInspect, HandleRosterUpdate, ScanGear
+local WipeTextFrames, Refresh, SendGuildGearSyncRequest, ShouldUseCommScan, RequestNextInspect, HandleRosterUpdate, ScanGear, CreateDisplayFrame
 
-function frame:CreateTab(title, OnShowFn)
+local function IsDisplayShown()
+	return frame and frame:IsShown()
+end
+
+local function CreateTab(title, OnShowFn)
 	local i = #tabs + 1
 	tabs[i] = OnShowFn
 	---@class DBMGearTabButton: Button
 	---@field Text FontString
 	local _tab = CreateFrame("Button", nil, frame, "PanelTabButtonTemplate")
 	tabsBtn[i] = _tab
-	PanelTemplates_SetNumTabs(self, i)
+	PanelTemplates_SetNumTabs(frame, i)
 	if i == 1 then
-		_tab:SetPoint("TOPLEFT", self, "BOTTOMLEFT", 11, 2)
+		_tab:SetPoint("TOPLEFT", frame, "BOTTOMLEFT", 11, 2)
 	else
 		_tab:SetPoint("TOPLEFT", tabsBtn[i - 1], "TOPRIGHT", 1, 0)
 	end
 	_tab.Text:SetText(title)
 	_tab:SetScript("OnClick", function()
-		self:ShowTab(i)
+		PanelTemplates_SetTab(frame, i)
+		WipeTextFrames()
+		selectedTab = i
+		tabs[i]()
 	end)
 end
 
-function frame:ShowTab(tab)
-	PanelTemplates_SetTab(self, tab)
+local function ShowTab(tab)
+	PanelTemplates_SetTab(frame, tab)
 	WipeTextFrames()
 	selectedTab = tab
 	tabs[tab]()
 end
-
-local scroll = CreateFrame("ScrollFrame", nil, frame, "ScrollFrameTemplate")
-scroll:SetPoint("TOPLEFT", frame, "TOPLEFT", 8, -50)
-scroll:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -24, 30)
-
-local child = CreateFrame("Frame", nil, scroll)
-scroll:SetScrollChild(child)
-child:SetSize(scroll:GetWidth(), scroll:GetHeight())
-child:SetPoint("LEFT")
-
-local refresh = CreateFrame("Button", nil, frame)
-refresh:SetSize(20, 20)
-refresh:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 8, 6)
-refresh:SetText("REFRESH")
-refresh:Show()
-refresh:SetNormalTexture("Interface\\Buttons\\UI-RefreshButton")
-refresh:SetPushedTexture("Interface\\Buttons\\UI-RefreshButton-Down")
-refresh:SetHighlightTexture("Interface\\Buttons\\UI-RefreshButton")
-refresh:SetScript("OnClick", function()
-	if selectedTab == 1 then
-		Refresh()
-	elseif selectedTab == 2 then
-		if ShouldUseCommScan() and IsInGuild() then
-			SendGuildGearSyncRequest()
-		end
-	end
-end)
 
 function WipeTextFrames()
 	for _frame in next, usedTextFrames do
@@ -162,43 +122,6 @@ local function GetTextFrame()
 	return _frame
 end
 
-local titlePlayer = GetTextFrame()
-titlePlayer.Keep = true
-titlePlayer:SetFontObject(GameFontNormalLarge)
-titlePlayer:SetText(PLAYER)
-titlePlayer:SetPoint("TOPLEFT", child, 7, 0)
-local playerWidth = 120
-titlePlayer:SetWidth(playerWidth)
-
-local titleItemLevel = GetTextFrame()
-titleItemLevel.Keep = true
-titleItemLevel:SetFontObject(GameFontNormalLarge)
-titleItemLevel:SetText(_G["ITEM_LEVEL_ABBR"] or "iLvl")
-titleItemLevel:SetPoint("LEFT", titlePlayer, "RIGHT", 0, 0)
-
-local itemLevelWidth = mmax(75, titleItemLevel:GetStringWidth() + 20)
-titleItemLevel:SetWidth(itemLevelWidth)
-
-local titleMissingGems = GetTextFrame()
-titleMissingGems.Keep = true
-titleMissingGems:SetFontObject(GameFontNormalLarge)
-titleMissingGems:SetText(L.GEAR_MISSING_GEMS)
-titleMissingGems:SetPoint("LEFT", titleItemLevel, "RIGHT", 0, 0)
-
-local missingGemsWidth = mmax(55, titleMissingGems:GetStringWidth() + 20)
-titleMissingGems:SetWidth(missingGemsWidth)
-
-local titleMissingEnchants = GetTextFrame()
-titleMissingEnchants.Keep = true
-titleMissingEnchants:SetFontObject(GameFontNormalLarge)
-titleMissingEnchants:SetText(L.GEAR_MISSING_ENCHANTS)
-titleMissingEnchants:SetPoint("LEFT", titleMissingGems, "RIGHT", 0, 0)
-
-local missingEnchantsWidth = mmax(55, titleMissingEnchants:GetStringWidth() + 20)
-titleMissingEnchants:SetWidth(missingEnchantsWidth)
-
-child:SetWidth(playerWidth + itemLevelWidth + missingGemsWidth + missingEnchantsWidth + 8)
-frame:SetWidth(child:GetWidth() + 32)
 
 local function SetPlayerGearState(name, itemLevel, missingGems, missingEnchants, pending, unavailable)
 	local player = DBM:GetRaidRoster()[name]
@@ -343,6 +266,9 @@ local function UpdateGuildTab()
 end
 
 local function Update()
+	if not IsDisplayShown() then
+		return
+	end
 	if selectedTab == 1 then
 		UpdateRaidTab()
 	elseif selectedTab == 2 then
@@ -409,14 +335,14 @@ local function RemovePendingInspect(name)
 end
 
 local function SendGearSyncRequest()
-	if not frame:IsShown() or not private.sendSync or not ShouldUseCommScan() or not next(pendingCommReplies) then
+	if not IsDisplayShown() or not private.sendSync or not ShouldUseCommScan() or not next(pendingCommReplies) then
 		return
 	end
 	commRequestToken = commRequestToken + 1
 	local requestToken = commRequestToken
 	private.sendSync(private.DBMSyncProtocol or 1, "GIQ", nil, "NORMAL")
 	C_Timer.After(commReplyTimeoutSeconds, function()
-		if not frame:IsShown() or requestToken ~= commRequestToken then
+		if not IsDisplayShown() or requestToken ~= commRequestToken then
 			return
 		end
 		local queuedInspect = false
@@ -435,7 +361,7 @@ local function SendGearSyncRequest()
 end
 
 function SendGuildGearSyncRequest()
-	if not frame:IsShown() or not private.sendGuildSync or not ShouldUseCommScan() or not IsInGuild() then
+	if not IsDisplayShown() or not private.sendGuildSync or not ShouldUseCommScan() or not IsInGuild() then
 		return
 	end
 	wipe(guildGearData)
@@ -460,7 +386,7 @@ function SendGuildGearSyncRequest()
 			return
 		end
 		guildGearQuerySent = false
-		if not frame:IsShown() or selectedTab ~= 2 then
+		if not IsDisplayShown() or selectedTab ~= 2 then
 			return
 		end
 		Update()
@@ -557,7 +483,7 @@ local function FinishInspect(token, itemLevel, missingGems, missingEnchants)
 	if activeInspect.token ~= token then
 		wipe(activeInspect)
 		ClearInspectPlayer()
-		if pendingRosterRefresh and frame:IsShown() then
+		if pendingRosterRefresh and IsDisplayShown() then
 			pendingRosterRefresh = false
 			HandleRosterUpdate()
 		end
@@ -574,14 +500,14 @@ local function FinishInspect(token, itemLevel, missingGems, missingEnchants)
 	wipe(activeInspect)
 	ClearInspectPlayer()
 	Update()
-	if pendingRosterRefresh and frame:IsShown() then
+	if pendingRosterRefresh and IsDisplayShown() then
 		pendingRosterRefresh = false
 		HandleRosterUpdate()
 		return
 	end
-	if frame:IsShown() and #pendingInspects > 0 then
+	if IsDisplayShown() and #pendingInspects > 0 then
 		C_Timer.After(0.1, function()
-			if frame:IsShown() and not activeInspect.name then
+			if IsDisplayShown() and not activeInspect.name then
 				RequestNextInspect()
 			end
 		end)
@@ -589,7 +515,7 @@ local function FinishInspect(token, itemLevel, missingGems, missingEnchants)
 end
 
 function RequestNextInspect()
-	if not frame:IsShown() or activeInspect.name then
+	if not IsDisplayShown() or activeInspect.name then
 		return
 	end
 	if InCombatLockdown() or UnitAffectingCombat("player") or (InspectFrame and InspectFrame:IsShown()) then
@@ -742,7 +668,7 @@ end
 
 local function OnEvent(_, event, arg1)
 	if event == "GROUP_ROSTER_UPDATE" then
-		if frame:IsShown() then
+		if IsDisplayShown() then
 			if activeInspect.name then
 				pendingRosterRefresh = true
 			else
@@ -750,7 +676,7 @@ local function OnEvent(_, event, arg1)
 			end
 		end
 	elseif event == "PLAYER_REGEN_ENABLED" then
-		if frame:IsShown() and #pendingInspects > 0 and not activeInspect.name then
+		if IsDisplayShown() and #pendingInspects > 0 and not activeInspect.name then
 			RequestNextInspect()
 		end
 	elseif event == "INSPECT_READY" then
@@ -771,21 +697,121 @@ local function OnUpdate(_, elapsed)
 		return
 	end
 	inspectUpdateElapsed = 0
-	if frame:IsShown() and #pendingInspects > 0 and not activeInspect.name then
+	if IsDisplayShown() and #pendingInspects > 0 and not activeInspect.name then
 		RequestNextInspect()
 	end
 end
 
-frame:SetScript("OnHide", function()
-	frame:UnregisterEvent("GROUP_ROSTER_UPDATE")
-	frame:UnregisterEvent("INSPECT_READY")
-	frame:UnregisterEvent("PLAYER_REGEN_ENABLED")
-	frame:SetScript("OnEvent", nil)
-	frame:SetScript("OnUpdate", nil)
-	pendingRosterRefresh = false
-	inspectUpdateElapsed = 0
-	ClearInspectQueue()
-end)
+function CreateDisplayFrame()
+	if frame then
+		return frame
+	end
+	frame = CreateFrame("Frame", "DBMGearCheckFrame", UIParent, "DefaultPanelTemplate") --[[@as DefaultPanelTemplate]]
+	tinsert(_G["UISpecialFrames"], frame:GetName())
+	frame:Hide()
+	frame:SetSize(380, 300)
+	frame:SetClampedToScreen(true)
+	frame:SetPoint("LEFT")
+	frame:SetFrameStrata("DIALOG")
+	frame:SetMovable(true)
+	frame:EnableMouse(true)
+	frame:RegisterForDrag("LeftButton")
+	frame:SetTitle(L.GEAR_HEADER)
+	frame:SetScript("OnDragStart", frame.StartMoving)
+	frame:SetScript("OnDragStop", function(self)
+		self:StopMovingOrSizing()
+		local point, _, _, x, y = self:GetPoint(1)
+		DBM.Options.GearPosition = {point, x, y}
+	end)
+	frame:SetScript("OnHide", function(self)
+		self:UnregisterEvent("GROUP_ROSTER_UPDATE")
+		self:UnregisterEvent("INSPECT_READY")
+		self:UnregisterEvent("PLAYER_REGEN_ENABLED")
+		self:SetScript("OnEvent", nil)
+		self:SetScript("OnUpdate", nil)
+		pendingRosterRefresh = false
+		inspectUpdateElapsed = 0
+		ClearInspectQueue()
+	end)
+
+	frame.Bg:SetTexture("Interface\\FrameGeneral\\UI-Background-Rock")
+	frame.Bg:SetColorTexture(0, 0, 0, 0.8)
+
+	local closeBtn = CreateFrame("Button", nil, frame, "UIPanelCloseButtonDefaultAnchors")
+	closeBtn:SetFrameLevel(frame.NineSlice:GetFrameLevel() + 10)
+
+	scroll = CreateFrame("ScrollFrame", nil, frame, "ScrollFrameTemplate")
+	scroll:SetPoint("TOPLEFT", frame, "TOPLEFT", 8, -50)
+	scroll:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -24, 30)
+
+	child = CreateFrame("Frame", nil, scroll)
+	scroll:SetScrollChild(child)
+	child:SetSize(scroll:GetWidth(), scroll:GetHeight())
+	child:SetPoint("LEFT")
+
+	local refresh = CreateFrame("Button", nil, frame)
+	refresh:SetSize(20, 20)
+	refresh:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 8, 6)
+	refresh:SetText("REFRESH")
+	refresh:Show()
+	refresh:SetNormalTexture("Interface\\Buttons\\UI-RefreshButton")
+	refresh:SetPushedTexture("Interface\\Buttons\\UI-RefreshButton-Down")
+	refresh:SetHighlightTexture("Interface\\Buttons\\UI-RefreshButton")
+	refresh:SetScript("OnClick", function()
+		if selectedTab == 1 then
+			Refresh()
+		elseif selectedTab == 2 and ShouldUseCommScan() and IsInGuild() then
+			SendGuildGearSyncRequest()
+		end
+	end)
+
+	playerWidth = 120
+	titlePlayer = GetTextFrame()
+	titlePlayer.Keep = true
+	titlePlayer:SetFontObject(GameFontNormalLarge)
+	titlePlayer:SetText(PLAYER)
+	titlePlayer:SetPoint("TOPLEFT", child, 7, 0)
+	titlePlayer:SetWidth(playerWidth)
+
+	titleItemLevel = GetTextFrame()
+	titleItemLevel.Keep = true
+	titleItemLevel:SetFontObject(GameFontNormalLarge)
+	titleItemLevel:SetText(_G["ITEM_LEVEL_ABBR"] or "iLvl")
+	titleItemLevel:SetPoint("LEFT", titlePlayer, "RIGHT", 0, 0)
+	itemLevelWidth = mmax(75, titleItemLevel:GetStringWidth() + 20)
+	titleItemLevel:SetWidth(itemLevelWidth)
+
+	titleMissingGems = GetTextFrame()
+	titleMissingGems.Keep = true
+	titleMissingGems:SetFontObject(GameFontNormalLarge)
+	titleMissingGems:SetText(L.GEAR_MISSING_GEMS)
+	titleMissingGems:SetPoint("LEFT", titleItemLevel, "RIGHT", 0, 0)
+	missingGemsWidth = mmax(55, titleMissingGems:GetStringWidth() + 20)
+	titleMissingGems:SetWidth(missingGemsWidth)
+
+	titleMissingEnchants = GetTextFrame()
+	titleMissingEnchants.Keep = true
+	titleMissingEnchants:SetFontObject(GameFontNormalLarge)
+	titleMissingEnchants:SetText(L.GEAR_MISSING_ENCHANTS)
+	titleMissingEnchants:SetPoint("LEFT", titleMissingGems, "RIGHT", 0, 0)
+	missingEnchantsWidth = mmax(55, titleMissingEnchants:GetStringWidth() + 20)
+	titleMissingEnchants:SetWidth(missingEnchantsWidth)
+
+	child:SetWidth(playerWidth + itemLevelWidth + missingGemsWidth + missingEnchantsWidth + 8)
+	frame:SetWidth(child:GetWidth() + 32)
+
+	CreateTab(GROUP, function()
+		if IsDisplayShown() then
+			Refresh()
+		end
+	end)
+	CreateTab(GUILD, function()
+		if ShouldUseCommScan() and IsInGuild() then
+			SendGuildGearSyncRequest()
+		end
+	end)
+	return frame
+end
 
 function GearCheck:Show()
 	if DBM.Keystones then
@@ -793,38 +819,29 @@ function GearCheck:Show()
 	end
 	DBM.Durability:Hide()
 	DBM.Latency:Hide()
+	local displayFrame = CreateDisplayFrame()
 	if _G["DBM_GUI_OptionsFrame"] then
-		frame:SetFrameLevel(_G["DBM_GUI_OptionsFrame"]:GetFrameLevel() + 10)
+		displayFrame:SetFrameLevel(_G["DBM_GUI_OptionsFrame"]:GetFrameLevel() + 10)
 	end
-	frame:ClearAllPoints()
+	displayFrame:ClearAllPoints()
 	local position = DBM.Options.GearPosition
 	if type(position) ~= "table" or not validAnchorPoints[position[1]] or type(position[2]) ~= "number" or type(position[3]) ~= "number" then
 		position = {"RIGHT", -150, 0}
 	end
-	frame:SetPoint(position[1], position[2], position[3])
-	frame:RegisterEvent("GROUP_ROSTER_UPDATE")
-	frame:RegisterEvent("INSPECT_READY")
-	frame:RegisterEvent("PLAYER_REGEN_ENABLED")
-	frame:SetScript("OnEvent", OnEvent)
-	frame:SetScript("OnUpdate", OnUpdate)
-	if #tabs == 0 then
-		frame:CreateTab(GROUP, function()
-			if frame:IsShown() then
-				Refresh()
-			end
-		end)
-		frame:CreateTab(GUILD, function()
-			if ShouldUseCommScan() and IsInGuild() then
-				SendGuildGearSyncRequest()
-			end
-		end)
-	end
-	frame:Show()
-	frame:ShowTab(1)
+	displayFrame:SetPoint(position[1], position[2], position[3])
+	displayFrame:RegisterEvent("GROUP_ROSTER_UPDATE")
+	displayFrame:RegisterEvent("INSPECT_READY")
+	displayFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
+	displayFrame:SetScript("OnEvent", OnEvent)
+	displayFrame:SetScript("OnUpdate", OnUpdate)
+	displayFrame:Show()
+	ShowTab(1)
 end
 
 function GearCheck:Hide()
-	frame:Hide()
+	if frame then
+		frame:Hide()
+	end
 end
 
 function GearCheck:OnSync(event, sender, itemLevel, missingGems, missingEnchants, classToken)
@@ -860,7 +877,7 @@ function GearCheck:OnSync(event, sender, itemLevel, missingGems, missingEnchants
 			SetPlayerGearState(sender, nil, nil, nil, true, false)
 			tinsert(pendingInspects, sender)
 		end
-		if frame:IsShown() then
+		if IsDisplayShown() then
 			Update()
 			if #pendingInspects > 0 and not activeInspect.name then
 				RequestNextInspect()
@@ -902,11 +919,11 @@ function GearCheck:OnSync(event, sender, itemLevel, missingGems, missingEnchants
 		missingGems = mmax(0, mfloor(missingGems or 0))
 		missingEnchants = mmax(0, mfloor(missingEnchants or 0))
 		guildGearData[sender] = {class = classToken, itemLevel = itemLevel, missingGems = missingGems, missingEnchants = missingEnchants}
-		if frame:IsShown() and selectedTab == 2 and not guildUpdatePending then
+		if IsDisplayShown() and selectedTab == 2 and not guildUpdatePending then
 			guildUpdatePending = true
 			C_Timer.After(guildUpdateDebounceSeconds, function()
 				guildUpdatePending = false
-				if frame:IsShown() and selectedTab == 2 then
+				if IsDisplayShown() and selectedTab == 2 then
 					Update()
 				end
 			end)

--- a/DBM-Core/modules/gui/Latency.lua
+++ b/DBM-Core/modules/gui/Latency.lua
@@ -24,50 +24,10 @@ if not LibLatency then
 	return
 end
 
-local frame = CreateFrame("Frame", "DBMLatencyFrame", UIParent, "DefaultPanelTemplate") --[[@as DefaultPanelTemplate]]
-tinsert(_G["UISpecialFrames"], frame:GetName())
-frame:Hide()
-frame:SetSize(380, 300)
-frame:SetClampedToScreen(true)
-frame:SetPoint("LEFT")
-frame:SetFrameStrata("DIALOG")
-frame:SetMovable(true)
-frame:EnableMouse(true)
-frame:RegisterForDrag("LeftButton")
-frame:SetTitle(L.LAG_HEADER)
-frame:SetScript("OnDragStart", frame.StartMoving)
-frame:SetScript("OnDragStop", function(self)
-	self:StopMovingOrSizing()
-	local point, _, _, x, y = self:GetPoint(1)
-	DBM.Options.LatencyPosition = {point, x, y}
-end)
-
-frame.Bg:SetTexture("Interface\\FrameGeneral\\UI-Background-Rock")
-frame.Bg:SetColorTexture(0, 0, 0, 0.8)
-
-local closeBtn = CreateFrame("Button", nil, frame, "UIPanelCloseButtonDefaultAnchors")
-closeBtn:SetFrameLevel(frame.NineSlice:GetFrameLevel() + 10)
-
-local scroll = CreateFrame("ScrollFrame", nil, frame, "ScrollFrameTemplate")
-scroll:SetPoint("TOPLEFT", frame, "TOPLEFT", 8, -30)
-scroll:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -24, 30)
-
-local child = CreateFrame("Frame", nil, scroll)
-scroll:SetScrollChild(child)
-child:SetSize(scroll:GetWidth(), scroll:GetHeight())
-child:SetPoint("LEFT")
-
-local refresh = CreateFrame("Button", nil, frame)
-refresh:SetSize(20, 20)
-refresh:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 8, 6)
-refresh:SetText("REFRESH")
-refresh:Show()
-refresh:SetNormalTexture("Interface\\Buttons\\UI-RefreshButton")
-refresh:SetPushedTexture("Interface\\Buttons\\UI-RefreshButton-Down")
-refresh:SetHighlightTexture("Interface\\Buttons\\UI-RefreshButton")
-refresh:SetScript("OnClick", function()
-	LibLatency:RequestLatency()
-end)
+---@type DefaultPanelTemplate?
+local frame
+local scroll, child, titlePlayer, titleWorld, titleHome
+local worldWidth, homeWidth
 
 -- Frames handler
 local spareTextFrames, usedTextFrames = {}, {}
@@ -102,40 +62,93 @@ local function GetTextFrame()
 	return _frame
 end
 
-local titlePlayer = GetTextFrame()
-titlePlayer.Keep = true
-titlePlayer:SetFontObject(GameFontNormalLarge)
-titlePlayer:SetText(PLAYER)
-titlePlayer:SetPoint("TOPLEFT", child, 7, 0)
-titlePlayer:SetWidth(120)
+local function CreateFrame()
+	if frame then
+		return frame
+	end
+	frame = _G.CreateFrame("Frame", "DBMLatencyFrame", UIParent, "DefaultPanelTemplate") --[[@as DefaultPanelTemplate]]
+	tinsert(_G["UISpecialFrames"], frame:GetName())
+	frame:Hide()
+	frame:SetSize(380, 300)
+	frame:SetClampedToScreen(true)
+	frame:SetPoint("LEFT")
+	frame:SetFrameStrata("DIALOG")
+	frame:SetMovable(true)
+	frame:EnableMouse(true)
+	frame:RegisterForDrag("LeftButton")
+	frame:SetTitle(L.LAG_HEADER)
+	frame:SetScript("OnDragStart", frame.StartMoving)
+	frame:SetScript("OnDragStop", function(self)
+		self:StopMovingOrSizing()
+		local point, _, _, x, y = self:GetPoint(1)
+		DBM.Options.LatencyPosition = {point, x, y}
+	end)
 
-local titleWorld = GetTextFrame()
-titleWorld.Keep = true
-titleWorld:SetFontObject(GameFontNormalLarge)
-titleWorld:SetText(WORLD)
-titleWorld:SetPoint("LEFT", titlePlayer, "RIGHT", 0, 0)
-titleWorld:SetWidth(75)
+	frame.Bg:SetTexture("Interface\\FrameGeneral\\UI-Background-Rock")
+	frame.Bg:SetColorTexture(0, 0, 0, 0.8)
 
-local titleHome = GetTextFrame()
-titleHome.Keep = true
-titleHome:SetFontObject(GameFontNormalLarge)
-titleHome:SetText(HOME)
-titleHome:SetPoint("LEFT", titleWorld, "RIGHT")
-titleHome:SetWidth(75)
+	local closeBtn = _G.CreateFrame("Button", nil, frame, "UIPanelCloseButtonDefaultAnchors")
+	closeBtn:SetFrameLevel(frame.NineSlice:GetFrameLevel() + 10)
 
-local worldWidth, homeWidth = mmax(75, titleWorld:GetStringWidth() + 20), mmax(75, titleHome:GetStringWidth() + 20)
-titleWorld:SetWidth(worldWidth)
-titleHome:SetWidth(homeWidth)
+	scroll = _G.CreateFrame("ScrollFrame", nil, frame, "ScrollFrameTemplate")
+	scroll:SetPoint("TOPLEFT", frame, "TOPLEFT", 8, -30)
+	scroll:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -24, 30)
 
--- Update main frame width
-child:SetWidth(120 + worldWidth + homeWidth + 8)
-frame:SetWidth(child:GetWidth() + 32)
+	child = _G.CreateFrame("Frame", nil, scroll)
+	scroll:SetScrollChild(child)
+	child:SetSize(scroll:GetWidth(), scroll:GetHeight())
+	child:SetPoint("LEFT")
+
+	local refresh = _G.CreateFrame("Button", nil, frame)
+	refresh:SetSize(20, 20)
+	refresh:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 8, 6)
+	refresh:SetText("REFRESH")
+	refresh:Show()
+	refresh:SetNormalTexture("Interface\\Buttons\\UI-RefreshButton")
+	refresh:SetPushedTexture("Interface\\Buttons\\UI-RefreshButton-Down")
+	refresh:SetHighlightTexture("Interface\\Buttons\\UI-RefreshButton")
+	refresh:SetScript("OnClick", function()
+		LibLatency:RequestLatency()
+	end)
+
+	titlePlayer = GetTextFrame()
+	titlePlayer.Keep = true
+	titlePlayer:SetFontObject(GameFontNormalLarge)
+	titlePlayer:SetText(PLAYER)
+	titlePlayer:SetPoint("TOPLEFT", child, 7, 0)
+	titlePlayer:SetWidth(120)
+
+	titleWorld = GetTextFrame()
+	titleWorld.Keep = true
+	titleWorld:SetFontObject(GameFontNormalLarge)
+	titleWorld:SetText(WORLD)
+	titleWorld:SetPoint("LEFT", titlePlayer, "RIGHT", 0, 0)
+	titleWorld:SetWidth(75)
+
+	titleHome = GetTextFrame()
+	titleHome.Keep = true
+	titleHome:SetFontObject(GameFontNormalLarge)
+	titleHome:SetText(HOME)
+	titleHome:SetPoint("LEFT", titleWorld, "RIGHT")
+	titleHome:SetWidth(75)
+
+	worldWidth, homeWidth = mmax(75, titleWorld:GetStringWidth() + 20), mmax(75, titleHome:GetStringWidth() + 20)
+	titleWorld:SetWidth(worldWidth)
+	titleHome:SetWidth(homeWidth)
+
+	child:SetWidth(120 + worldWidth + homeWidth + 8)
+	frame:SetWidth(child:GetWidth() + 32)
+	return frame
+end
 
 local function SortLag(v1, v2)
 	return (v1.worldlag or 9999) < (v2.worldlag or 9999)
 end
 
 local function Update()
+	if not frame or not frame:IsShown() then
+		return
+	end
 	local sortLag = {}
 	for _, v in pairs(DBM:GetRaidRoster()) do
 		tinsert(sortLag, v)
@@ -194,15 +207,19 @@ function Latency:Show()
 		DBM.GearCheck:Hide()
 	end
 	DBM.Durability:Hide()
-	LibLatency:RequestLatency()
+	local displayFrame = CreateFrame()
 	if _G["DBM_GUI_OptionsFrame"] then
-		frame:SetFrameLevel(_G["DBM_GUI_OptionsFrame"]:GetFrameLevel() + 10)
+		displayFrame:SetFrameLevel(_G["DBM_GUI_OptionsFrame"]:GetFrameLevel() + 10)
 	end
-	frame:ClearAllPoints()
-	frame:SetPoint(DBM.Options.LatencyPosition[1], DBM.Options.LatencyPosition[2], DBM.Options.LatencyPosition[3])
-	frame:Show()
+	displayFrame:ClearAllPoints()
+	displayFrame:SetPoint(DBM.Options.LatencyPosition[1], DBM.Options.LatencyPosition[2], DBM.Options.LatencyPosition[3])
+	displayFrame:Show()
+	Update()
+	LibLatency:RequestLatency()
 end
 
 function Latency:Hide()
-	frame:Hide()
+	if frame then
+		frame:Hide()
+	end
 end

--- a/DBM-GUI/DBM-GUI_Mainline.toc
+++ b/DBM-GUI/DBM-GUI_Mainline.toc
@@ -81,7 +81,6 @@ modules\options\filters\Privacy.lua
 
 modules\options\frames\Frames.lua
 modules\options\frames\InfoFrame.lua
-modules\options\frames\Nameplate.lua
 
 modules\options\dev\Dev.lua
 


### PR DESCRIPTION
## Summary

This PR reduces load-time and hidden-state work across several optional DBM-Core presentation features:

- Mainline no longer loads the full nameplate renderer or its dedicated options panel, because nameplate rendering is unavailable in current Midnight content.
- The Classic nameplate renderer creates its root only when DBM-owned rendering is actually needed and cleans pooled icon glow/update state explicitly.
- RangeCheck keeps its always-available distance APIs while lazily creating and activating its manual UI.
- Latency, Durability, and Gear retain their always-on request/cache services while constructing presentation panels only on first use.
- BattleRezTimer creates its frame only for an enabled supported combat or manual preview.

The changes deliberately preserve compatibility APIs and mandatory communication behavior. This is a lifecycle optimization, not a change to encounter logic or the underlying latency protocol.

## Motivation

Optional UI should have effectively zero runtime cost until it is used:

- no unnecessary frames at addon load;
- no hidden UI layout or rendering work;
- no event/update machinery for unavailable features;
- mandatory request listeners must remain functional even when their presentation UI is closed.

Previously, Mainline loaded the complete Classic-capable nameplate implementation even though its public `Show` path immediately rejected Post-Midnight clients. Several user-facing tools also created complete panels at addon load, and Latency/Durability rebuilt hidden UI whenever their libraries delivered data.

## Changes

### Mainline nameplate load boundary

- Replaced `DBM-Nameplate.lua` with `DBM-Nameplate-Mainline.lua` in `DBM-Core_Mainline.toc`.
- Added a minimal Mainline compatibility shim exposing:
  - `DBM.Nameplate:Show()`
  - `DBM.Nameplate:Hide()`
  - `DBM.Nameplate:IsShown()`
  - `DBM.Nameplate:UpdateIconOptions()`
  - `DBM.Nameplate:ValidateFontSettings()`
  - `DBM.PauseTestTimer()`
- The shim creates no frames, registers no events or callbacks, and performs no rendering work.
- Removed the dedicated Nameplate options panel from `DBM-GUI_Mainline.toc`.
- Existing Global Disables nameplate controls were already inside the non-PostMidnight branch, so no additional change was required there.

This keeps old modules and external callers safe while avoiding the full renderer cost on Mainline.

### Classic nameplate safety

No non-Mainline Core or GUI `.toc` files are changed. Vanilla, TBC, Wrath, Cata, and Mists continue loading the full `DBM-Nameplate.lua` implementation and Nameplate options panel.

The retained renderer was hardened without changing its public API or third-party handoff behavior:

- The internal `DBMNameplate` root is created only when DBM-owned rendering is first required.
- Kui/ThreatPlates/Plater handoff paths return before creating the internal renderer.
- Removing an icon clears its OnUpdate and explicitly stops active glow state before pooling/hiding it.
- Missing LibCustomGlow is handled safely instead of attempting method calls.
- Root `NAME_PLATE_UNIT_ADDED` registration remains scoped to active internal rendering.

Sorting, timer cadence, and pool policy are intentionally unchanged pending measurement.

### Lazy RangeCheck UI

- Preserved `GetDistance()` and `GetDistanceAll()` for `DBM:CheckNearby()` and existing encounter modules.
- Deferred the controller frame and repeating animation group until the first successful UI open.
- Text-only mode no longer creates the radar frame or its 40 textures.
- Separated unit class/icon metadata from radar dots so the text display does not depend on radar allocation.
- Registers roster, raid-target, and combat events only while the range window is open.
- `Hide()` stops the animation, clears its loop callback, and unregisters only RangeCheck-owned events.
- Allows the text range window inside an instance while out of combat.
- Entering combat inside an instance closes the window fully and does not automatically reopen it afterward.

### Lazy latency panel

- Kept LibLatency discovery and `LibLatency:Register("DBM", callback)` at module load.
- Continued updating the DBM raid-roster latency cache when responses arrive while the panel is closed.
- Stopped hidden callbacks before they allocate a sort table, sort the roster, recycle/create font strings, or update scroll layout.
- Moved construction of `DBMLatencyFrame`, its scroll child, refresh control, headers, and text-frame pool to an idempotent first-use factory.
- `Latency:Hide()` is safe before the panel has ever been created.
- On show, the panel is positioned and displayed, populated from cached values, and then requests fresh latency data. Showing before the request also preserves rendering if the library invokes a callback synchronously.

LibLatency itself remains loaded and listening. This PR does not unregister or otherwise interfere with its request/response service.

### Lazy durability panel

Durability now follows the same service/presentation split as Latency:

- LibDurability remains loaded and registered for the addon lifetime.
- Hidden responses continue updating `durpercent` and `durbroken` in DBM's roster cache.
- Hidden responses no longer allocate/sort display data or update font strings and scroll layout.
- `DBMDurabilityFrame` and all child UI are constructed on first show.
- Cached rows are rendered before requesting fresh data, preserving synchronous and asynchronous callback behavior.

### Lazy Gear panel with permanent responder

- `DBM.GearCheck` and `GearCheck:OnSync()` remain available from file load.
- `AddonComms.lua` can continue routing `GIQ`, `GIR`, `GGQ`, and `GGR` before the panel exists.
- Incoming `GIQ` and `GGQ` requests still scan local gear and send replies while the panel has never been opened.
- The named panel, tabs, scroll child, refresh button, headers, and row pool are created on first show.
- Inspect events and the inspect OnUpdate remain visible-panel scoped and are removed on hide.
- Rendering entrypoints return immediately unless the panel is visible.

### Lazy BattleRez display

- Removed the unconditional load-time call to `CreateDisplayFrame()`.
- Creates `DBMBattleRezTimerFrame` only for an enabled supported combat or manual preview.
- Preserves the existing one-second active ticker, option-off cancellation, preview auto-hide, saved positioning, and font validation.

## Behavior preserved

- Existing `DBM.Nameplate` call sites remain valid on Mainline and become intentional no-ops.
- Classic Nameplate rendering and configuration remain loaded through their existing client-specific `.toc` files.
- Latency requests still use `LibLatency:RequestLatency()`.
- Incoming latency data still updates `raid[sender].homelag` and `raid[sender].worldlag` while the panel is hidden.
- The latency panel retains its global frame name, saved position, close behavior, refresh button, roster sorting, class coloring, and mutual exclusion with the Gear, Durability, and Keystone panels.
- LibDurability remains registered and continues updating the roster cache while its panel is hidden.
- Gear still answers group and guild requests without requiring its UI to be open.
- RangeCheck distance helpers retain their existing implementations and signatures.
- BattleRez combat support detection and ticker behavior are unchanged once enabled.

## Safety considerations

- The Mainline shim intentionally preserves the complete public method surface used by current DBM modules and test helpers.
- The shim and full renderer are mutually exclusive through client-specific `.toc` files.
- The LuaLS duplicate-field diagnostic is suppressed only in the shim because the language server analyzes both mutually exclusive implementations together.
- No LibLatency listener or callback registration was moved behind the UI factory.
- No LibDurability listener or callback registration was moved behind the UI factory.
- Gear comm-handler registration and request-response paths remain independent of frame construction.
- RangeCheck recurring UI work is stopped on hide and on instance combat entry.
- No encounter timing, warning, scheduler, combat-detection, or distance-check logic is changed.

## Validation performed

- [x] `luac -p` passes for the changed/new Lua files.
- [x] LuaLS reports no diagnostics in the changed/new Lua files.
- [x] `git diff --check` passes.
- [x] Static `.toc` review confirms Mainline loads only `DBM-Nameplate-Mainline.lua`.
- [x] Static `.toc` review confirms non-Mainline variants continue loading the full Nameplate implementation and panel.
- [x] Static review confirms LibLatency registration remains at file load.
- [x] Static review confirms LibDurability registration remains at file load.
- [x] Static review confirms Gear `GIQ`/`GGQ` response paths do not require panel creation.
- [x] Static review confirms RangeCheck `GetDistance`/`GetDistanceAll` bodies are unchanged.

## In-game validation requested

- [x] On Mainline, load DBM without opening the latency panel and confirm `DBMLatencyFrame` has not been created.
- [x] From another grouped client, request/report latency while the DBM latency panel is unopened and confirm LibLatency communication still works.
- [x] Open `/dbm lag` and confirm cached rows appear immediately, followed by fresh responses.
- [x] Close and reopen the latency panel; verify refresh, class colors, scrolling, dragging, and saved position.
- [x] Repeat the unopened/hidden request test for LibDurability, then verify its panel, refresh, dragging, and saved position.
- [x] From a second client, send Gear group and guild requests before the local Gear panel has opened and confirm replies are returned.
- [ ] Open Gear and verify group/guild tabs, comm-first scan, inspect fallback, pending-scan cancellation on hide, and reopen behavior.
- [x] Confirm Gear, Durability, Latency, and Keystone panels still hide one another normally.
- [ ] On Mainline, exercise an old-content module that calls `DBM.Nameplate:Show()`/`Hide()` and confirm there are no errors and no `DBMNameplate` renderer frame is created.
- [x] On Classic, verify internal Nameplate rendering and third-party handoff, including update, pause, resume, stop, stop-all, plate disappearance, and combat cleanup.
- [x] Verify RangeCheck outdoors and inside an instance out of combat, text-only mode, radar mode, reverse mode, saved positions, instance-combat shutdown, and manual reopen after combat.
- [x] Verify BattleRez automatic combat display, option-off behavior, preview toggle/auto-hide, dragging, and saved font/position.

## Out of scope

This PR does not change:

- LibLatency protocol/listener behavior;
- LibDurability protocol/listener behavior;
- LibKeystone protocol/listener behavior or the Keystone panel lifecycle;
- RangeCheck distance calculations;
- encounter-module Nameplate call sites;
- Arrow, Flash, InfoFrame, or other optional UI lifecycles;
- scheduler, anti-spam, combat-detection, or warning timing behavior.

Those areas can be evaluated independently so this patch remains small and easy to verify.
